### PR TITLE
chore: :wrench: Create custom conventional branch names to use.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,13 @@
   "autoDocstring.includeName": true,
   "autoDocstring.startOnNewLine": true,
   "editor.tabCompletion": "on",
-  "editor.snippetSuggestions": "inline"
+  "editor.snippetSuggestions": "inline",
+  "conventional-branch.type": [
+    "docs",
+    "feat",
+    "fix",
+    "build",
+    "chore"
+  ],
+  "conventional-branch.format": "{Type}/{Branch}"
 }


### PR DESCRIPTION
I want to start using Conventional Branches, but the options for names don't work well for our purposes. So I updated them.