### PR TITLE
build: :rocket: Setup Fly.io settings and configuration files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+fly.toml
+.git/
+*.sqlite3

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to Fly.io
+
+# Only trigger when pushed/merged to main
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Deploy to Fly.io
+        uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG PYTHON_VERSION=3.10-slim-bullseye
+
+FROM python:${PYTHON_VERSION}
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir -p /code
+
+WORKDIR /code
+
+RUN pip install poetry
+COPY pyproject.toml poetry.lock /code/
+RUN poetry config virtualenvs.create false
+RUN poetry install --only main --no-root --no-interaction
+COPY . /code
+
+EXPOSE 8000
+
+CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "seedcase_sprout.wsgi"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,30 @@
+# fly.toml app configuration file generated for seedcase-sprout on 2024-01-09T18:05:29+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "seedcase-sprout"
+primary_region = "ams"
+console_command = "/code/manage.py shell"
+
+[build]
+
+[env]
+  PORT = "8000"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 512
+
+[[statics]]
+  guest_path = "/code/static"
+  url_prefix = "/static/"

--- a/seedcase_sprout/settings.py
+++ b/seedcase_sprout/settings.py
@@ -125,3 +125,8 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Fly.io deployment settings
+# TODO: This should probably be turned off when installed by others, since this is for demo only.
+APP_NAME = os.environ.get("FLY_APP_NAME")
+ALLOWED_HOSTS = [f"{APP_NAME}.fly.dev"] 


### PR DESCRIPTION
I ran `fly launch --org seedcase-project --no-deploy` and followed the instructions as well as those on the fly.io/docs/django pages.

@philter87, the `fly` cli automatically adds the `Dockerfile`, so we'll have to intergrate the one you added in PR #52 with this one (after either has been merged).

I haven't setup Postgres on Fly, because it asks for information that I don't really know how to answer. Maybe we can go over it in our next update meeting.

Closes #39, Closes #40