### PR TITLE
Fix/comment style in vscode settings json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,6 @@
     "refactor",//A code change that neither fixes a bug nor adds a feature//
     "style", //Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)//
     "test", //Adding missing tests or correcting existing tests//
-];
+],
   "conventional-branch.format": "{Type}/{Branch}"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,14 +12,14 @@
   "editor.tabCompletion": "on",
   "editor.snippetSuggestions": "inline",
   "conventional-branch.type": [
-    "build",  # Changes that affect the build system or external dependencies
-    "ci", # Changes to our CI configuration files and scripts
-    "docs", # Documentation only changes
-    "feat", # A new feature
-    "fix", # A bug fix
-    "refactor",# A code change that neither fixes a bug nor adds a feature
-    "style", # Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-    "test", # Adding missing tests or correcting existing tests
+    "build",  //Changes that affect the build system or external dependencies//
+    "ci", //Changes to our CI configuration files and scripts//
+    "docs", //Documentation only changes//
+    "feat", //A new feature//
+    "fix", //A bug fix//
+    "refactor",//A code change that neither fixes a bug nor adds a feature//
+    "style", //Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)//
+    "test", //Adding missing tests or correcting existing tests//
 ];
   "conventional-branch.format": "{Type}/{Branch}"
 }


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR fixes the comment style (#) in the settings.json file since this is not a valid comment style for json (which does not accept comments at all, actually).
- I noticed that VS Code didn't like the comments in the settings.json and found that VS Code have a "json with comments" mode (.jsonc) which ´settings.json´ apparently is under the hood (see [vs code documentation](https://code.visualstudio.com/docs/languages/json#_json-with-comments) for reference)
- In addition, I have changed a semi colon to a comma 

## Testing

- [ ] Yes
- [X] No, not needed (give a reason below)
- [ ] No, I need help writing them

Tests are not needed for the settings.json.  

## Reviewer Focus

Reviewers should focus on whether I have made a syntax error somewhere (but I have only changed `#` to `// //` and `;` to `.`, so there isn't be much to review)