### PR TITLE
fix: move whitenoise up under securitymiddleware

### DIFF
--- a/seedcase_sprout/settings.py
+++ b/seedcase_sprout/settings.py
@@ -48,8 +48,8 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR moves the whitenoise up under securitymiddleware in settings.py as described in the [whitenoise docs](https://whitenoise.readthedocs.io/en/latest/django.html#enable-whitenoise).

## Related Issues

<!-- List issues the PR closes -->

Closes #103 