### PR TITLE
Feat/just generate single puml

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,10 @@
 generate-puml-all:
   docker run --rm -v $(pwd):/puml -w /puml ghcr.io/plantuml/plantuml:latest -tpng "**/*.puml"
 
+# Generate PNG image from specific PlantUML file
+generate-puml name:
+  docker run --rm -v  $(pwd):/puml -w /puml ghcr.io/plantuml/plantuml:latest -tpng "**/{{name}}.puml"
+
 # Start up the docker container
 start-docker:
   docker compose up -d

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 @_default:
     just --list --unsorted
 
-# Generate PNG images from PlantUML files
-generate-puml:
+# Generate PNG images from all PlantUML files
+generate-puml-all:
   docker run --rm -v $(pwd):/puml -w /puml ghcr.io/plantuml/plantuml:latest -tpng "**/*.puml"
 
 # Start up the docker container


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds a command to the just file to create a png from a specific puml
- In addition, it renames the command to create pnga for all pumls from `generate-puml` to `generate-puml-all`

This is useful, when only one png needs to be updated (because we currently have pumls that are in progress which we don't include pngs for). The `generate-puml` command put out pngs for all pumls which does not fit what I am currently doing with updating the user flow diagrams (and don't want to include pngs for e.g., the runtime-view pumls).

Hope this makes sense :) 
