### PR TITLE
Feat/progress bar for file upload

### DIFF
--- a/app/templates/file-drop-zone.html
+++ b/app/templates/file-drop-zone.html
@@ -48,6 +48,12 @@
   </div>
 </form>
 
+<!-- Progress bar dialog -->
+<dialog id="progress-dialog">
+  <h5>Extracting Column Metadata</h5>
+  <progress></progress>
+</dialog>
+
 <script>
   function query(id) {
     return document.querySelector("#" + id);

--- a/app/templates/file-drop-zone.html
+++ b/app/templates/file-drop-zone.html
@@ -42,7 +42,7 @@
   <p class="grey-text">Supported formats: .csv</p>
 
   <div class="row center-align">
-    <button disabled id="submit_button" type="submit" value="OK">
+    <button disabled id="submit_button" type="submit" value="OK" onclick="showDialog()">
       EXTRACT DATA STRUCTURE
     </button>
   </div>
@@ -61,6 +61,8 @@
 
   const highlightClass = "file-upload-box-highlight"
   const dragZone = query("drag_zone")
+  const dialog = document.getElementById("progress-dialog"); 
+
 
   function selectedFiles(files) {
     const isFilesListEmpty = files.length === 0;
@@ -94,4 +96,9 @@
     e.preventDefault()
     dragZone.classList.add(highlightClass)
   }, false)
+
+
+  function showDialog() { 
+  dialog.show(); 
+} 
 </script>

--- a/app/templates/file-drop-zone.html
+++ b/app/templates/file-drop-zone.html
@@ -61,7 +61,6 @@
 
   const highlightClass = "file-upload-box-highlight"
   const dragZone = query("drag_zone")
-  const dialog = document.getElementById("progress-dialog"); 
 
 
   function selectedFiles(files) {
@@ -99,6 +98,7 @@
 
 
   function showDialog() { 
-  dialog.show(); 
+    const dialog = document.getElementById("progress-dialog")
+    dialog.show(); 
 } 
 </script>

--- a/app/views/file_upload.py
+++ b/app/views/file_upload.py
@@ -1,3 +1,4 @@
+import time
 from typing import IO, Dict
 
 from django.core.files.uploadhandler import StopUpload
@@ -49,6 +50,9 @@ def handle_post_request_with_file(request: HttpRequest,
         validate_csv_and_save_columns(table_id, request.FILES)
     except StopUpload as upload_error:
         return render_file_upload_page(request, table_id, upload_error.args[0])
+
+    # wait to sec (to show the progress bar)
+    time.sleep(2)
 
     return redirect("/edit-table-columns/" + str(table_id))
 


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds a progress bar after the user clicks "Extract Data Structure" at the file upload page. The progress bar is shown for two seconds just to show it off for now. Currently, the extraction progress is so fast that it would otherwise be shown for a very short time, which would be confusing (since you can't even read the title before it's gone again). The plan is to remove the two second wait, when the extraction is finalised.
    - Alternatively, a spinner could be added instead, if the extraction of column metadata is so fast that it doesn't make sense to have a progress bar.  
- I have left out a function that tracks how far we are in the extraction progress that should be shown in the progress bar for now, since the extraction isn't finished yet - and maybe we don't need it when the extraction process is pretty fast? 

Screenshot showing the progress bar:
![image](https://github.com/seedcase-project/seedcase-sprout/assets/40836345/a0b538e8-e3f8-453e-87f8-2ffadc24315c)


## Related Issues

<!-- List issues the PR closes -->

Closes #90. 

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->

See also #91 (which I have omitted for now, and I'm not sure we need it). 

## Testing

- [ ] Yes
- [X] No, not needed (give a reason below)
- [ ] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->

I don't think tests are needed for this. It's just showing the progress bar for two seconds before going to the next page. 

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR requires an in-depth review. 

Discussion point: Should we omit the function to track how far we are in the extraction progress, when it doesn't take that long? Might this change/be slower later, so we would actually need to track the progress?  

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [ ] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated (nothing to update)

