### PR TITLE
fix: port 10000 -> 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can run the Django application with docker:
 # Run application
 docker compose up -d
 
-Check "http://localhost:10000"
+Check "http://localhost:8000"
 
 # Terminate application
 docker compose down


### PR DESCRIPTION
Update that docker uses port 8000 (and not 10000 anymore) in README.md