### PR TITLE
fix: Handle static assets when DEBUG=False

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ docs
 fly.toml
 .git/
 *.sqlite3
+staticfiles

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ junit/
 # MacO
 .DS_Store
 
-# R and RStudio 
+# R and RStudio
 .Rbuildignore
 .Rhistory
 .RData
@@ -92,3 +92,4 @@ site
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+staticfiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,8 @@ COPY . /code
 
 EXPOSE 8000
 
-# CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "seedcase_sprout.wsgi"]
-ENTRYPOINT ["/bin/bash", "-c" , "poetry run python manage.py migrate && poetry run gunicorn seedcase_sprout.wsgi --bind 0.0.0.0:8000"]
+# The entrypoint executes three things:
+# - "python manage.py collectstatic". Static assets are copied to STATIC_ROOT
+# - "python manage.py migrate". The migrations are applied to the database
+# - "gunicorn seedcase_sprout.wsgi --bind 0.0.0.0:8000". gunicorn (application server) runs the application
+ENTRYPOINT ["/bin/bash", "-c" , "poetry run python manage.py collectstatic --no-input  && poetry run python manage.py migrate && poetry run gunicorn seedcase_sprout.wsgi --bind 0.0.0.0:8000"]

--- a/seedcase_sprout/settings.py
+++ b/seedcase_sprout/settings.py
@@ -135,7 +135,7 @@ Serving static files are handled differently depending on the DEBUG-flag:
   - Before running the application run `python manage.py collectstatic` to copy all
     static assets to STATIC_ROOT
   - Install whitenoise. Whitenoise will serve the static assets from the Django app.
-    The other alternatives seems more complicated:
+    The other alternatives seems more complicated.
 """
 
 STATIC_URL = "static/"

--- a/seedcase_sprout/settings.py
+++ b/seedcase_sprout/settings.py
@@ -122,20 +122,21 @@ USE_I18N = True
 
 USE_TZ = True
 
+"""
+Static files (CSS, JavaScript, Images)
+Serving static files are handled differently depending on the DEBUG-flag:
 
-# Static files (CSS, JavaScript, Images)
-# Serving static files are handled differently depending on the DEBUG-flag:
-#
-# - DEBUG=True. The development server automatically serves static assets
-#   located in "static" folders. E.g "app/static" and "admin/static"
-#
-# - DEBUG=False. The static assets are not handled automatically. We need
-#   to do three things:
-#   - Configure STATIC_ROOT which is the central location for static assets
-#   - Before running the application run `python manage.py collectstatic` to copy all
-#     static assets to STATIC_ROOT
-#   - Install whitenoise. Whitenoise will serve the static assets from the Django app.
-#     The other alternatives seems more complicated:
+- DEBUG=True. The development server automatically serves static assets
+  located in "static" folders. E.g "app/static" and "admin/static"
+
+- DEBUG=False. The static assets are not handled automatically. We need
+  to do three things:
+  - Configure STATIC_ROOT which is the central location for static assets
+  - Before running the application run `python manage.py collectstatic` to copy all
+    static assets to STATIC_ROOT
+  - Install whitenoise. Whitenoise will serve the static assets from the Django app.
+    The other alternatives seems more complicated:
+"""
 
 STATIC_URL = "static/"
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')

--- a/seedcase_sprout/settings.py
+++ b/seedcase_sprout/settings.py
@@ -124,9 +124,21 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/4.2/howto/static-files/
+# Serving static files are handled differently depending on the DEBUG-flag:
+#
+# - DEBUG=True. The development server automatically serves static assets
+#   located in "static" folders. E.g "app/static" and "admin/static"
+#
+# - DEBUG=False. The static assets are not handled automatically. We need
+#   to do three things:
+#   - Configure STATIC_ROOT which is the central location for static assets
+#   - Before running the application run `python manage.py collectstatic` to copy all
+#     static assets to STATIC_ROOT
+#   - Install whitenoise. Whitenoise will serve the static assets from the Django app.
+#     The other alternatives seems more complicated:
 
 STATIC_URL = "static/"
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Description

- This PR fixes the issue of serving static assets when DEBUG=False

This fixes the issues related to the main deployment at https://seedcase-sprout.fly.dev, see below for some of the errors. This is a result of static assets not being served when DEBUG=False

![image](https://github.com/seedcase-project/seedcase-sprout/assets/5868902/e9507e5c-4ccc-4f9e-ad81-caced4f8aa8f)


## Related Issues

<!-- List issues the PR closes -->

Closes #151 #152 #153 


## Testing

- [X] Yes
- [] No, not needed (give a reason below)
- [ ] No, I need help writing them

I have tested it by deploying it directly to seedcase-sprout.fly.dev and it seems to work, but we can verify in the preview environment as well. (If we set the DJANGO_DEBUG=False)

## Reviewer Focus

This PR only needs a quick review. Start with the settings.py. The multiline comment explains the changes

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
