### PR TITLE
style: double quotes around staticfiles to follow black formatting

### DIFF
--- a/seedcase_sprout/settings.py
+++ b/seedcase_sprout/settings.py
@@ -140,7 +140,7 @@ Serving static files are handled differently depending on the DEBUG-flag:
 """
 
 STATIC_URL = "static/"
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds double quotes around staticfiles to follow black formatting. 

Since this is a minor style change, I'll just merge it. 
