### PR TITLE
build: :rewind: I accidentally changed this to the wrong value, should be app

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ primary_region = "ams"
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
-  processes = ["sprout"]
+  processes = ["app"]
 
 [[vm]]
   cpu_kind = "shared"


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR reverts a change I made in the `fly.toml` file, which made deployment break. The `processes` should be `"app"`, I had accidentally renamed it to `"sprout"` (thinking it related to the app folder.