### PR TITLE
Fix/table name suggestions

### DIFF
--- a/sprout/forms.py
+++ b/sprout/forms.py
@@ -22,7 +22,7 @@ class TableMetadataForm(ModelForm):
 
         # Adding 'autocomplete: new-password' to disable suggestions on input field
         widgets = {
-            'name': Textarea(attrs={"autocomplete": "new-password"}),
+            "name": Textarea(attrs={"autocomplete": "new-password"}),
         }
 
     def clean_name(self) -> str:

--- a/sprout/forms.py
+++ b/sprout/forms.py
@@ -21,6 +21,7 @@ class TableMetadataForm(ModelForm):
         fields = ["name", "description"]
 
         # Adding 'autocomplete: new-password' to disable suggestions on input field
+        # TODO: Look into other solutions for this? (later)
         widgets = {
             "name": Textarea(attrs={"autocomplete": "new-password"}),
         }

--- a/sprout/forms.py
+++ b/sprout/forms.py
@@ -1,5 +1,5 @@
 """Module defining forms."""
-from django.forms import CharField, ModelForm
+from django.forms import CharField, ModelForm, Textarea
 
 from sprout.models import ColumnMetadata, TableMetadata
 from sprout.validators import (
@@ -19,6 +19,11 @@ class TableMetadataForm(ModelForm):
 
         model = TableMetadata
         fields = ["name", "description"]
+
+        # Adding 'autocomplete: new-password' to disable suggestions on input field
+        widgets = {
+            'name': Textarea(attrs={"autocomplete": "new-password"}),
+        }
 
     def clean_name(self) -> str:
         """Clean and validate field name.

--- a/sprout/templates/data-import.html
+++ b/sprout/templates/data-import.html
@@ -41,14 +41,14 @@
     {% if form.name.errors %}
     <div style="margin-bottom:50px;" class="field label invalid border">
       {{form.name}}
-      <label>Name</label>
+      <label>Table Name</label>
       <span class="error"> {{form.name.errors|striptags}} </span>
     </div>
     <!-- else: validation is successful -->
     {% else %}
     <div class="field label border">
       {{form.name}}
-      <label>Name</label>
+      <label>Table Name</label>
       <span class="helper">Name of the table you want to create</span>
     </div>
     {% endif %}

--- a/sprout/templates/data-import.html
+++ b/sprout/templates/data-import.html
@@ -41,14 +41,14 @@
     {% if form.name.errors %}
     <div style="margin-bottom:50px;" class="field label invalid border">
       {{form.name}}
-      <label>Table Name</label>
+      <label>Name</label>
       <span class="error"> {{form.name.errors|striptags}} </span>
     </div>
     <!-- else: validation is successful -->
     {% else %}
     <div class="field label border">
       {{form.name}}
-      <label>Table Name</label>
+      <label>Name</label>
       <span class="helper">Name of the table you want to create</span>
     </div>
     {% endif %}

--- a/sprout/templates/data-import.html
+++ b/sprout/templates/data-import.html
@@ -34,7 +34,7 @@
 <!-- Create table dialog -->
 <dialog class="dialog {% if form.name.errors %}active{% endif %}" id="create-table-dialog">
   <h5 class="center-align">Create new table</h5>
-  <form method="post" autocomplete="off">
+  <form method="post">
     {% csrf_token %}
     <!-- name field -->
     <!-- if validation fails -->

--- a/sprout/templates/data-import.html
+++ b/sprout/templates/data-import.html
@@ -34,7 +34,7 @@
 <!-- Create table dialog -->
 <dialog class="dialog {% if form.name.errors %}active{% endif %}" id="create-table-dialog">
   <h5 class="center-align">Create new table</h5>
-  <form method="post">
+  <form method="post" autocomplete="off">
     {% csrf_token %}
     <!-- name field -->
     <!-- if validation fails -->


### PR DESCRIPTION
## Description

- This PR fixes a bug. We don't want any suggestions when finding a name for a table (before it would show many different names)

This solution is a bit weird, but Chrome is acting weird on Windows. You need to add the attribute 'autocomplete: "new-password"'. You can read more here (but you really don't need to): https://stackoverflow.com/questions/43132693/how-to-turn-off-html-input-form-field-suggestions

## Related Issues

Closes #231 


## Testing

- [ ] Yes
- [X] No, not needed (give a reason below)
- [ ] No, I need help writing them

Was tested manually on Chrome Windows. 
We should also test on:
- Safari Mac
- Chrome Mac
- Chrome Linux
- Firefox Linux


## Reviewer Focus
This PR only needs a quick review.

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [ ] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated