### PR TITLE
ci: :construction_worker: Add token that gives permission to write (delete) environments

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -49,5 +49,5 @@ jobs:
         if: ${{ github.event.action == 'closed' }}
         with:
           # ⚠️ The provided token needs permission for admin write:org
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DELETE_ENV_TOKEN }}
           environment: pr-${{ github.event.number }}


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

Hopefully this will allow PR environments to be deleted. But can only find out after merging... I've added a token that gives permission to write to environments and deployments. So hopefully this should delete them after PR's are merged and closed.

## Related Issues

<!-- List issues the PR closes -->

Related to #227
