### PR TITLE
fix: The folder staticfiles is automatically created to avoid the war…

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -146,6 +146,10 @@ Serving static files are handled differently depending on the DEBUG-flag:
 STATIC_URL = "static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
+# Create staticfiles if missing to avoid warning in tests
+if not os.path.exists(STATIC_ROOT):
+    os.mkdir(STATIC_ROOT)
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 


### PR DESCRIPTION
## Description


- This PR fixes a small bug. A warning about missing a folder called staticfiles when running tests

## Related Issues

Closes #253 

## Testing
- [X] Yes
- [ ] No, not needed (give a reason below)
- [ ] No, I need help writing them

## Reviewer Focus
This PR only needs a quick review.

## Checklist

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
