### PR TITLE
fix: save method is overridden and a test is added (SMALL)

### DIFF
--- a/sprout/models/table_metadata.py
+++ b/sprout/models/table_metadata.py
@@ -39,5 +39,3 @@ class TableMetadata(models.Model):
             self.modified_at = datetime.datetime.now(datetime.UTC)
 
         super().save(*args, **kwargs)
-
-

--- a/sprout/models/table_metadata.py
+++ b/sprout/models/table_metadata.py
@@ -1,4 +1,6 @@
 """Module defining the TableMetaData model."""
+import datetime
+
 from django.conf import settings
 from django.db import models
 
@@ -16,10 +18,26 @@ class TableMetadata(models.Model):
         on_delete=models.PROTECT,
         related_name="creator",
     )
-    modified_at = models.DateTimeField(auto_now=True)
+    modified_at = models.DateTimeField(null=True)
     modified_by = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
         on_delete=models.PROTECT,
         related_name="modifier",
     )
+
+    def save(self, *args, **kwargs) -> None:
+        """Overriding the default save-method.
+
+        The modified_at should only change when modified and not when created.
+
+        Args:
+            *args: non-keyworded arguments required by Django
+            **kwargs: keyworded arguments required by Django
+        """
+        if self.id:
+            self.modified_at = datetime.datetime.now(datetime.UTC)
+
+        super().save(*args, **kwargs)
+
+

--- a/sprout/tests/tests_models_table_and_column_metadata.py
+++ b/sprout/tests/tests_models_table_and_column_metadata.py
@@ -2,7 +2,7 @@
 from django.test import TestCase
 
 from sprout.models import ColumnMetadata, TableMetadata
-from sprout.tests.db_test_utils import create_metadata_table_and_column
+from sprout.tests.db_test_utils import create_metadata_table_and_column, create_table
 
 
 class TableAndColumnMetadataTests(TestCase):
@@ -61,3 +61,18 @@ class TableAndColumnMetadataTests(TestCase):
         self.assertEqual(1, table_count, "Table should not be deleted")
         column_count = ColumnMetadata.objects.count()
         self.assertEqual(0, column_count, "Column should be deleted")
+
+    def test_modified_at_should_be_null_on_creation(self):
+        # Arrange
+        table_name = "TestTable"
+        table = create_table(table_name)
+        table.save()
+        initial_modified_at = table.modified_at
+
+        # Act
+        table.original_file_name = "A change"
+        table.save()
+
+        # Assert
+        self.assertIsNone(initial_modified_at, "modified_at should be null")
+        self.assertIsNotNone(table.modified_at, "modified_at should NOT be null")


### PR DESCRIPTION
## Description

- This PR fixes the bug that modified_at is not null when created but equal to created

This is a very small pr.

## Related Issues

Closes #122 

## Testing

- [X] Yes
- [ ] No, not needed (give a reason below)
- [ ] No, I need help writing them

## Reviewer Focus
This PR only needs a quick review.


## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated