### PR TITLE
test: adding test for another csv format (SMALL)

### DIFF
--- a/sprout/tests/tests_csv_reader.py
+++ b/sprout/tests/tests_csv_reader.py
@@ -86,6 +86,19 @@ class CsvTests(TestCase):
         self.assert_types(df, "Int64", "Float64", "Boolean", "String")
         self.assert_values(df["s1"], "Hi, Man", "Hello?", "What, about")
 
+    def test_csv_with_quotes_and_aligned(self):
+        # Testing leading whitespace except for quoted strings with comma
+        csv_content = """
+        "Index", "Item",                    "Cost",     "Tax",  "Total"
+        6,"Banana Boat Sunscreen, 8 oz",    6.68,       0.50,   7.18
+        9,"Bertoli Alfredo Sauce",          2.12,       0.16,   2.28"""
+        csv_file = self.create_file(csv_content)
+
+        df = read_csv_file(csv_file)
+
+        self.assert_types(df, "Int64", "String", "Float64", "Float64", "Float64")
+        self.assertEqual(2, len(df))
+
     def test_boolean_ish_values(self):
         """Column with boolean-ish/empty values should convert to booleans."""
         csv_file = self.create_file(


### PR DESCRIPTION
## Description

- This PR adds a test to illustrate more formats and a limitation for the CSV file. Leading whitespace is okay for most data types, except for quoted strings with a semicolon. ` "Some text, and some other text"` 

## Related Issues

Closes #262 

## Testing

- [X] Yes
- [ ] No, not needed (give a reason below)
- [ ] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
This PR only needs a quick review.

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
