### PR TITLE
Feat/tabindex added to description

### DIFF
--- a/sprout/templates/column-review-list.html
+++ b/sprout/templates/column-review-list.html
@@ -12,10 +12,10 @@
 
   <h5>Extracted field name: {{ form.instance.original_name }}</h5>
   <article class="border">
-    <p>Column name: {{ form.name }}</p>
-    <p>Display name: {{ form.title }}</p>
-    <p>Description: {{ form.description|tabindex:forloop.counter }}</p>
-    <p>Data Type: {{ form.data_type }}</p>
+    <p>Column name: {{ form.name|tabindex:1 }}</p>
+    <p>Display name: {{ form.title|tabindex:2 }}</p>
+    <p>Description: {{ form.description|tabindex:3 }}</p>
+    <p>Data Type: {{ form.data_type|tabindex:4 }}</p>
     <input type="hidden" name="{{ form.prefix }}-id" value="{{ form.instance.id }}">
   </article>
 

--- a/sprout/templates/column-review-list.html
+++ b/sprout/templates/column-review-list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load tabindex %}
 
 {% block content %}
 
@@ -13,7 +14,7 @@
   <article class="border">
     <p>Column name: {{ form.name }}</p>
     <p>Display name: {{ form.title }}</p>
-    <p>Description: {{ form.description }}</p>
+    <p>Description: {{ form.description|tabindex:forloop.counter }}</p>
     <p>Data Type: {{ form.data_type }}</p>
     <input type="hidden" name="{{ form.prefix }}-id" value="{{ form.instance.id }}">
   </article>

--- a/sprout/templates/column-review.html
+++ b/sprout/templates/column-review.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load tabindex %}
 
 {% block content %}
 
@@ -25,7 +26,7 @@
         <td>{{ form.instance.original_name }}</td>
         <td>{{ form.name }}</td>
         <td>{{ form.title }}</td>
-        <td style="overflow: hidden;">{{ form.description }}</td>
+        <td style="overflow: hidden;">{{ form.description|tabindex:forloop.counter }}</td>
         <td style="overflow: hidden;">{{ form.data_type }}</td>
         <td>{{ form.allow_missing_value }}</td>
         <td>{{ form.allow_duplicate_value }}</td>

--- a/sprout/templates/column-review.html
+++ b/sprout/templates/column-review.html
@@ -24,12 +24,12 @@
       {% for form in forms %}
       <tr>
         <td>{{ form.instance.original_name }}</td>
-        <td>{{ form.name }}</td>
-        <td>{{ form.title }}</td>
-        <td style="overflow: hidden;">{{ form.description|tabindex:forloop.counter }}</td>
-        <td style="overflow: hidden;">{{ form.data_type }}</td>
-        <td>{{ form.allow_missing_value }}</td>
-        <td>{{ form.allow_duplicate_value }}</td>
+        <td>{{ form.name|tabindex:1 }}</td>
+        <td>{{ form.title|tabindex:2 }}</td>
+        <td style="overflow: hidden;">{{ form.description|tabindex:3 }}</td>
+        <td style="overflow: hidden;">{{ form.data_type|tabindex:4 }}</td>
+        <td>{{ form.allow_missing_value|tabindex:5 }}</td>
+        <td>{{ form.allow_duplicate_value|tabindex:6 }}</td>
         <input type="hidden" name="{{ form.prefix }}-id" value="{{ form.instance.id }}">
       </tr>
       {% endfor %}

--- a/sprout/templates/metadata-review.html
+++ b/sprout/templates/metadata-review.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load tabindex %}
 
 {% block content %}
   <h2 style="margin-bottom: 20px">Headers for {{ table_metadata.name }}</h2>
@@ -33,7 +34,7 @@
             </div>
 
             <div class="field label small border" style="margin-bottom: 20px">
-              {{ column.form.description }}
+              {{ column.form.description|tabindex:forloop.counter }}
               <label>Description</label>
             </div>
 

--- a/sprout/templates/metadata-review.html
+++ b/sprout/templates/metadata-review.html
@@ -17,24 +17,24 @@
             <p
               style="text-align: center; font-size: 1.25rem; font-weight: bold; margin-bottom: 20px">{{ column.title }}</p>
             <div class="field label small border" style="margin-bottom: 40px">
-              {{ column.form.title }}
+              {{ column.form.title|tabindex:1 }}
               <label>Title</label>
               <span class="helper">From: '{{ column.original_name }}'</span>
             </div>
 
             <div hidden>
-              {{ column.form.name }}
+              {{ column.form.name|tabindex:2 }}
             </div>
 
 
             <div class="field label suffix border" style="margin-bottom: 20px">
-              {{ column.form.data_type }}
+              {{ column.form.data_type|tabindex:3 }}
               <label>Type</label>
               <i>arrow_drop_down</i>
             </div>
 
             <div class="field label small border" style="margin-bottom: 20px">
-              {{ column.form.description|tabindex:forloop.counter }}
+              {{ column.form.description|tabindex:4 }}
               <label>Description</label>
             </div>
 
@@ -54,7 +54,7 @@
       {% endfor %}
     </div>
     <div class="row" style="justify-content: center">
-      <button type="submit">Update All</button>
+      <button type="submit" tabindex=10>Update All</button>
     </div>
   </form>
 {% endblock content %}

--- a/sprout/templatetags/__init__.py
+++ b/sprout/templatetags/__init__.py
@@ -1,0 +1,1 @@
+"""Custom template tags module required by Django."""

--- a/sprout/templatetags/tabindex.py
+++ b/sprout/templatetags/tabindex.py
@@ -1,0 +1,20 @@
+from django.template.defaulttags import register
+
+
+@register.filter
+def tabindex(value, index):
+    """Adds a custom template tag.
+
+    This adds a tabindex on a input field. The tabindex decides where the cursor will
+    go next when 'tab' is pressed. Example::
+
+        {{form.description | tabindex: 0}}
+
+    Will be converted to something like::
+
+        <input type=text name="description" tabindex=0>
+
+    Add a tabindex attribute to the widget for a bound field.
+    """
+    value.field.widget.attrs["tabindex"] = index
+    return value


### PR DESCRIPTION
## Description

- This PR adds a tabindex to the description fields. When the user hits 'tab' the cursor moves between description fields.

## Related Issues

Closes #274

## Testing

- [ ] Yes
- [X] No, not needed (give a reason below)
- [ ] No, I need help writing them

I have only done manual testing.

## Reviewer Focus
This PR only needs a quick review.

This is a quick review, but if you like you can read about django custom templatetags, which is a way to add python code to django templates. See more here: https://docs.djangoproject.com/en/4.2/howto/custom-template-tags/

## Checklist

- [ ] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [] Relevant documentation has been updated
