### PR TITLE
bug: Remove bfcache on back button click in firefox

### DIFF
--- a/sprout/templates/file-drop-zone.html
+++ b/sprout/templates/file-drop-zone.html
@@ -97,8 +97,13 @@
   }, false)
 
 
-  function showDialog() { 
+  function showDialog() {
     const dialog = document.getElementById("progress-dialog")
-    dialog.show(); 
-} 
+    dialog.show();
+  }
+
+  // This will disable the bfcache (back-forward cache) in firefox to ensure the page
+  // is reloaded, when user clicks the 'back button' in the browser
+  window.addEventListener('unload', function(){});
+  window.addEventListener('beforeunload', function(){});
 </script>


### PR DESCRIPTION
## Description

- This PR fixes bug. The loading bar in 'metadata-create' reappears when hitting 'back' button in chrome. This is solved by removing bgcache (back-forward cache) in firefox. (I did not know this was a thing)

## Related Issues

Closes #201

## Testing

- [ ] Yes
- [X] No, not needed (give a reason below)
- [ ] No, I need help writing them

Hard to create a unit test for this, but I have tested manually.

## Reviewer Focus
This PR only needs a quick review.

## Checklist

For all PRs that are not general documentation

- [] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
