### PR TITLE
style: :zap: align naming of urls to kebab case

### DIFF
--- a/sprout/templates/table-files.html
+++ b/sprout/templates/table-files.html
@@ -1,32 +1,32 @@
 {% extends 'base.html' %}
 
 {% block content %}
-  <h2>Files for&nbsp;<b>{{ table.name }}</b></h2>
-  <p>Here you can view and download the files relevant for this table.</p>
+<h2>Files for&nbsp;<b>{{ table.name }}</b></h2>
+<p>Here you can view and download the files relevant for this table.</p>
 
 
-  <!-- HTML table with files --->
-  <table class="medium-space stripes">
-    <thead>
-      <tr>
-        <th>File</th>
-        <th class="min right-align">Creation Time</th>
-        <th class="min right-align">Size</th>
-      </tr>
-    </thead>
-    <tbody>
+<!-- HTML table with files --->
+<table class="medium-space stripes">
+  <thead>
+    <tr>
+      <th>File</th>
+      <th class="min right-align">Creation Time</th>
+      <th class="min right-align">Size</th>
+    </tr>
+  </thead>
+  <tbody>
     {% for file in files %}
-      <tr>
-        <td>
-          <a href="{% url 'table_file_download' table_id=table.id file_id=file.id %}" class="row wave">
+    <tr>
+      <td>
+        <a href="{% url 'table-file-download' table_id=table.id file_id=file.id %}" class="row wave">
           <i>download</i>
           <div>{{ file.original_file_name }}</div>
-          </a>
-        </td>
-        <td class="min right-align">{{ file.created_at }}</td>
-        <td class="min right-align">{{ file.file_size_bytes | filesizeformat  }}</td>
-      </tr>
+        </a>
+      </td>
+      <td class="min right-align">{{ file.created_at }}</td>
+      <td class="min right-align">{{ file.file_size_bytes | filesizeformat }}</td>
+    </tr>
     {% endfor %}
-    </tbody>
-  </table>
+  </tbody>
+</table>
 {% endblock content %}

--- a/sprout/tests/tests_views_data_import.py
+++ b/sprout/tests/tests_views_data_import.py
@@ -9,7 +9,7 @@ from sprout.models import TableMetadata
 class DataImportTests(TestCase):
     """Tests for the data import view."""
 
-    url = reverse("data_import")
+    url = reverse("data-import")
     empty_form = {}
     invalid_form = {"name": "Test/Table", "description": "Test description"}
     valid_form = {"name": "TestTable", "description": "Test description"}

--- a/sprout/tests/tests_views_table_files.py
+++ b/sprout/tests/tests_views_table_files.py
@@ -20,7 +20,7 @@ class TableFilesTests(TestCase):
         file = io.BytesIO(b"File content")
         file.name = "file.csv"
         file_meta = FileMetadata.create_file_metadata(file, table.id)
-        url = reverse("table_files", kwargs={"table_id": table.id})
+        url = reverse("table-files", kwargs={"table_id": table.id})
 
         # Act
         response = self.client.post(url)

--- a/sprout/urls.py
+++ b/sprout/urls.py
@@ -6,17 +6,19 @@ from . import views
 
 urlpatterns = [
     path("", views.home, name="home"),
-    path("data-import", views.data_import, name="data_import"),
-    path("metadata/create/<int:table_id>", views.metadata_create),
+    path("data-import", views.data_import, name="data-import"),
+    path(
+        "metadata/create/<int:table_id>", views.metadata_create, name="metadata-create"
+    ),
     path(
         "column-review/<int:table_id>",
         views.column_review,
         name="column-review",
     ),
-    path("table-files/<int:table_id>", views.table_files, name="table_files"),
+    path("table-files/<int:table_id>", views.table_files, name="table-files"),
     path(
         "table-files/<int:table_id>/download/<int:file_id>",
         views.table_file_download,
-        name="table_file_download",
+        name="table-file-download",
     ),
 ]


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR aligns the url names to be kebab case, following Django Docs [examples](https://docs.djangoproject.com/en/5.0/topics/http/urls/#examples).
- These changes are done to ensure we keep to the same naming convention across urls. 
