### PR TITLE
fix: add that no spaces are allowed in error message

### DIFF
--- a/sprout/tests/tests_forms_tablemetadata.py
+++ b/sprout/tests/tests_forms_tablemetadata.py
@@ -1,4 +1,5 @@
 """Tests for forms."""
+
 from django.test import TestCase
 
 from sprout.forms import TableMetadataForm
@@ -25,9 +26,9 @@ class TableMetadataFormTests(TestCase):
         self.assertEqual(
             form.errors["name"],
             [
-                f"Please use only upper or lower case letters (a to z), "
-                f"numbers (0 to 9), -, or _ when "
-                f"specifying {list(form_data.keys())[0]}"
+                f"Please don't use spaces and only use upper or lower case letters "
+                f"(a to z), numbers (0 to 9), -, or _ when specifying "
+                f"{list(form_data.keys())[0]}",
             ],
         )
 
@@ -48,9 +49,9 @@ class TableMetadataFormTests(TestCase):
         self.assertEqual(
             form.errors["name"],
             [
-                f"Please use only upper or lower case letters (a to z), "
-                f"numbers (0 to 9), -, or _ when "
-                f"specifying {list(form_data.keys())[0]}"
+                f"Please don't use spaces and only use upper or lower case letters "
+                f"(a to z), numbers (0 to 9), -, or _ when specifying "
+                f"{list(form_data.keys())[0]}",
             ],
         )
 

--- a/sprout/tests/tests_validators.py
+++ b/sprout/tests/tests_validators.py
@@ -1,4 +1,5 @@
 """Tests for validators."""
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -31,8 +32,8 @@ class ValidateNoSpecialCharactersTests(TestCase):
         # Assert
         self.assertEqual(
             context.exception.message,
-            f"Please use only upper or lower case letters (a to z), numbers "
-            f"(0 to 9), -, or _ when specifying {field_name}",
+            f"Please don't use spaces and only use upper or lower case letters "
+            f"(a to z), numbers (0 to 9), -, or _ when specifying {field_name}",
         )
         self.assertEqual(context.exception.code, "invalid_value_special_characters")
 
@@ -55,8 +56,8 @@ class ValidateNoSpecialCharactersTests(TestCase):
         # Assert
         self.assertEqual(
             context.exception.message,
-            f"Please use only upper or lower case letters (a to z), numbers "
-            f"(0 to 9), -, or _ when specifying {field_name}",
+            f"Please don't use spaces and only use upper or lower case letters "
+            f"(a to z), numbers (0 to 9), -, or _ when specifying {field_name}",
         )
         self.assertEqual(context.exception.code, "invalid_value_special_characters")
 

--- a/sprout/validators.py
+++ b/sprout/validators.py
@@ -26,8 +26,8 @@ def validate_no_special_characters(field_name: str, field_value: str) -> None:
     """
     validator = RegexValidator(
         regex=r"^[-a-zA-Z0-9_]+$",
-        message=f"Please use only upper or lower case letters (a to z), "
-        f"numbers (0 to 9), -, or _ when specifying {field_name}",
+        message=f"Please don't use spaces and only use upper or lower case letters "
+        f"(a to z), numbers (0 to 9), -, or _ when specifying {field_name}",
         code="invalid_value_special_characters",
     )
     return validator(field_value)


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds the that no spaces are allowed when naming a table/metadata.
- These changes are done because after the user test today, where we noticed that this information could be included explicitly for clarity. 

## Related Issues

<!-- List issues the PR closes -->

Closes #314 

## Testing

- [X] No, not needed (give a reason below)

Already added.

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

- Maybe the error message sentence is a bit too long now? Or is it ok?
- Why does deploy fail here?

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
