### PR TITLE
feat: Support for decimals with comma is added

### DIFF
--- a/sprout/csv/csv_reader.py
+++ b/sprout/csv/csv_reader.py
@@ -84,6 +84,7 @@ def _transform_to_suitable_csv_format(csv_path: str, row_count: int | None) -> s
     df = df.select(pl.all().name.map(lambda n: n.strip().strip('"')))
     df = df.select(pl.all().str.strip_chars('"'))
 
+    df = df.select([_convert_decimal_with_comma_to_dot(column) for column in df])
     df = df.select([_convert_to_booleans_if_possible(column) for column in df])
 
     cleaned_path = csv_path + "cleaned"
@@ -104,6 +105,17 @@ BOOLEAN_MAPPING = {
     "0": False,
     "": None,
 }
+
+
+def _convert_decimal_with_comma_to_dot(series: pl.Series) -> pl.Series:
+    # Replace decimal with ',' with '.'
+    decimal_comma_regex = r"(\d+),(\d+)"
+    empty_count = series.is_null().sum()
+    match_count = series.str.count_matches(decimal_comma_regex).sum()
+    if empty_count + match_count == len(series):
+        return series.str.replace_all(decimal_comma_regex, "${1}.${2}")
+
+    return series
 
 
 def _convert_to_booleans_if_possible(series: Series) -> Series:

--- a/sprout/tests/tests_csv_reader.py
+++ b/sprout/tests/tests_csv_reader.py
@@ -99,6 +99,17 @@ class CsvTests(TestCase):
         self.assert_types(df, "Int64", "String", "Float64", "Float64", "Float64")
         self.assertEqual(2, len(df))
 
+    def test_csv_with_semicolon_seperator_and_comma_decimals(self):
+        """Testing with ; as separator and comma in decimals."""
+        csv_content = """index;value\n1;1,2\n2;2,3\n3;0,332\n4;"""
+        csv_file = self.create_file(csv_content)
+
+        df = read_csv_file(csv_file)
+
+        print(df)
+        self.assert_types(df, "Int64", "Float64")
+        self.assertEqual(4, len(df))
+
     def test_boolean_ish_values(self):
         """Column with boolean-ish/empty values should convert to booleans."""
         csv_file = self.create_file(

--- a/sprout/tests/tests_csv_reader.py
+++ b/sprout/tests/tests_csv_reader.py
@@ -106,7 +106,6 @@ class CsvTests(TestCase):
 
         df = read_csv_file(csv_file)
 
-        print(df)
         self.assert_types(df, "Int64", "Float64")
         self.assertEqual(4, len(df))
 


### PR DESCRIPTION
## Description

- This PR adds a feature. We want to support ';' as separator and ',' in decimals. This is not supported by polars by default (I think?)

## Related Issues

Closes #268

## Testing

- [X] Yes
- [ ] No, not needed (give a reason below)
- [ ] No, I need help writing them

## Reviewer Focus

Notes:
- I am solving this with regular expressions as part of the CSV preparation step. I don't know if there is a better way to do this? It seems a bit hacky. 
- All values in a column needs to match `r"(\d+),(\d+)"` or be empty, otherwise, the conversion is not applied.
- A value is only matched if there are numbers before and after the comma. Examples:
  - '12,345' is matched by the regex pattern and becomes '12.345'
  - 123 is not matched by the regex pattern but that is okay because I don't need to replace anything
  - ',12' is NOT matched by the regex! Should we support add support for this? I want to make the regular expression as 'tight' as possible. We can add support by using `r"(\d*),(\d+)"` instead. 

## Checklist
For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally