### PR TITLE
feat: :sparkles: add create new metadata dialog to metadata view and html

### DIFF
--- a/sprout/templates/project-id-metadata-view.html
+++ b/sprout/templates/project-id-metadata-view.html
@@ -27,9 +27,12 @@
   {% endfor %}
 </table>
 
+<!-- Create metadata dialog -->
+{% include 'includes/metadata-create-dialog.html' %}
+
 <!-- three buttons will submit this form: create, edit, or upload -->
 <nav class="right-align">
-  <a href="{% url 'data-import' %}" class="button"><i>add</i>Create new metadata</a>
+  <a class="button" data-ui="#create-metadata-dialog"><i>add</i>Create new metadata</a>
   <a href="#" class="button" id="edit-link" disabled><i>edit</i>Edit metadata</a>
   <a href="#" class="button" id="upload-link" disabled><i>upload</i>Upload data</a>
 

--- a/sprout/tests/tests_views_project_id_metadata_view.py
+++ b/sprout/tests/tests_views_project_id_metadata_view.py
@@ -35,13 +35,15 @@ class ProjectIdMetaDataTests(TestCase):
             file, self.table_metadata.pk
         )
 
+        self.url = reverse("project-id-metadata-view")
+        self.empty_form = {}
+        self.invalid_form = {"name": "Test/Table", "description": "Test description"}
+        self.valid_form = {"name": "TestTable", "description": "Test description"}
+
     def test_view_renders(self):
         """Test that the get function renders."""
-        # Arrange
-        url = reverse("project-id-metadata-view")
-
         # Act
-        response = self.client.get(url)
+        response = self.client.get(self.url)
 
         # Assert
         self.assertEqual(response.status_code, 200)
@@ -50,15 +52,70 @@ class ProjectIdMetaDataTests(TestCase):
     def test_view_shows_all_tables(self):
         """Test that the view shows all tables in TableMetadata."""
         # Arrange
-        url = reverse("project-id-metadata-view")
         create_table("Table1").save()
         create_table("Table2").save()
         tables = TableMetadata.objects.all()
 
         # Act
-        response = self.client.get(url)
+        response = self.client.get(self.url)
 
         # Assert
         self.assertEqual(response.status_code, 200)
         for table in tables:
             self.assertContains(response, table.name)
+
+    def test_fields_are_required(self):
+        """Test for when the required fields, name and description, are empty.
+
+        Tests that the expected errors occur when the form is empty (i.e., "This field
+        is required").
+        """
+        # Arrange/Act
+        response = self.client.post(self.url, self.empty_form)
+
+        # Assert
+        self.assertFormError(response, "form", "name", "This field is required.")
+        self.assertFormError(response, "form", "description", "This field is required.")
+
+    def test_redirect_with_valid_form(self):
+        """Test for redirect when the form is valid.
+        Tests that the page is redirected when a valid form is submitted.
+        """
+        # Arrange/Act
+        response = self.client.post(
+            self.url,
+            data=self.valid_form,
+        )
+        # Assert
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(
+            response, "/metadata/create/2"
+        )  # id is 2 because of the table created in the setUp method
+
+    def test_no_redirect_with_invalid_form_special_characters(self):
+        """Test that no redirection when the "name" field contains special characters.
+        Tests that the page isn't redirected when an invalid form with special
+        characters in the "name" field is submitted.
+        """
+        # Arrange/Act
+        response = self.client.post(
+            self.url,
+            data=self.invalid_form,
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_redirect_with_valid_form_table_exists(self):
+        """Test that page isn't redirected when a table with the submitted name exists.
+        Tests that page isn't redirected when a valid form with a table name that
+        already exists in the database is submitted.
+        """
+        # Arrange
+        TableMetadata.objects.create(name="TestTable", description="Test description")
+        # Act
+        response = self.client.post(
+            self.url,
+            data=self.valid_form,
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)

--- a/sprout/views/project_id_metadata_view.py
+++ b/sprout/views/project_id_metadata_view.py
@@ -1,8 +1,9 @@
 """File with column_review view."""
 
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
+from sprout.forms import TableMetadataForm
 from sprout.models import TableMetadata
 
 
@@ -20,10 +21,26 @@ def project_id_metadata_view(request: HttpRequest) -> HttpResponse:
     """
     existing_metadata = TableMetadata.objects.all()
 
+    # if POST, process the data in form (only happens when creating new metadata)
+    if request.method == "POST":
+        # create a form instance and populate it with data from the request
+        form = TableMetadataForm(data=request.POST)
+
+        # if input passes validation, save form and redirect to file upload
+        if form.is_valid():
+            table_metadata = form.save()
+
+            return redirect(to=f"metadata/create/{table_metadata.id}")
+
+    # if GET (or any other method), create a blank form
+    else:
+        form = TableMetadataForm(data=None)
+
     return render(
-        request,
-        "project-id-metadata-view.html",
-        {
+        request=request,
+        template_name="project-id-metadata-view.html",
+        context={
             "existing_metadata": existing_metadata,
+            "form": form,
         },
     )


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds the feature that clicking "create" on the metadata view page opens the create new metadata dialog. 
- These changes are done to fit the wireframes and complete the flow for clicking this button.

## Related Issues

<!-- List issues the PR closes -->

Closes #...

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->

See also Issues #162 

## Testing

- [X] Yes

Tests of the Create New Metadata dialog has been added by copying from existing tests from `tests_views_data_import.py`. My thoughts here are that we might remove the `data-import` view soon, so it's fine to copy the tests from there. Thoughts? 

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
