### PR TITLE
Feat/human readable string

### DIFF
--- a/sprout/models/column_metadata.py
+++ b/sprout/models/column_metadata.py
@@ -36,7 +36,7 @@ class ColumnMetadata(models.Model):
             table_metadata_id=table_id,
             extracted_name=series.name,
             machine_readable_name=_convert_to_snake_case(series.name),
-            display_name=series.name,
+            display_name=_convert_to_human_readable(series.name),
             description="",
             data_type=ColumnDataType.get_from_series(series),
             allow_missing_value=True,
@@ -69,3 +69,30 @@ def _convert_to_snake_case(string: str) -> str:
     altered_string = sub(r"([A-Z])([A-Z][a-z])", r"\1_\2", altered_string)
 
     return altered_string.lower()
+
+
+def _convert_to_human_readable(string: str) -> str:
+    """This function takes a string and converts it to human-readable title.
+
+    Examples:
+        snake_case --> Snake Case
+        PascalCase --> Pascal Case
+        CamelCase --> Camel Case
+        lower case  --> Lower Case
+        UPPER CASE --> Upper Case
+        UPPER_CASE --> Upper Case
+
+    Args:
+        string: A string to be converted
+
+    Returns:
+        A string converted to human-readable title
+    """
+    # Add space to snake_case names
+    string = sub("_", " ", string)
+
+    # Add space to CamelCase names
+    string = sub("([a-z])([A-Z])", r"\g<1> \g<2>", string)
+
+    # Capitalize first letter in words
+    return string.title()

--- a/sprout/templates/column-review.html
+++ b/sprout/templates/column-review.html
@@ -16,7 +16,6 @@
       <thead>
         <tr>
           <th>Extracted Name</th>
-          <th>Machine-Readable Name</th>
           <th>Display Name</th>
           <th>Description</th>
           <th>Data Type</th>
@@ -27,7 +26,6 @@
         {% for form in forms %}
           <tr>
             <td>{{ form.instance.extracted_name }}</td>
-            <td>{{ form.machine_readable_name|attr:'tabindex:1' }}</td>
             <td>{{ form.display_name|attr:'tabindex:2' }}</td>
             <td style="overflow: hidden;">{{ form.description|attr:'tabindex:3' }}</td>
             <td style="overflow: hidden;">{{ form.data_type|attr:'tabindex:4' }}</td>

--- a/sprout/templates/column-review.html
+++ b/sprout/templates/column-review.html
@@ -61,7 +61,7 @@
           <!-- CARD CONTENT -->
           <div style="min-width: 0; flex: 1; padding-top: 20px">
             <div class="row" style="margin-bottom: 20px">
-              <h3 class="max card-header">{{ column.display_name }}</h3>
+              <h3 class="max card-header">{{ column.extracted_name }}</h3>
               <label class="checkbox icon" style="z-index: 11">
                 {{ column.form.excluded|attr:'tabindex:5'|attr:'onclick:toggleExcluded(event)' }}
                 <span>
@@ -71,10 +71,9 @@
                 <div id="tooltip_{{ column.id }}" class="tooltip">Exclude</div>
               </label>
             </div>
-            <div class="field label small border" style="margin-bottom: 40px">
+            <div class="field label small border" style="margin-bottom: 20px">
               {{ column.form.display_name|attr:'tabindex:1' }}
-              <label>Display Name</label>
-              <span class="helper">From: '{{ column.extracted_name }}'</span>
+              <label>Display name</label>
             </div>
 
             <div hidden>{{ column.form.machine_readable_name|attr:'tabindex:2' }}</div>

--- a/sprout/tests/tests_human_readable.py
+++ b/sprout/tests/tests_human_readable.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+
+from sprout.models.column_metadata import _convert_to_human_readable
+
+
+class ConvertToHumanReadable(TestCase):
+    """Tests to convert to human-readable format."""
+
+    def test_snake_case_to_human_readable(self):
+        string = "snake_case"
+
+        human_readable = _convert_to_human_readable(string)
+
+        self.assertEqual("Snake Case", human_readable)
+
+    def test_pascal_case_to_human_readable(self):
+        string = "PascalCase"
+
+        human_readable = _convert_to_human_readable(string)
+
+        self.assertEqual("Pascal Case", human_readable)
+
+    def test_camel_case_to_human_readable(self):
+        string = "camelCase"
+
+        human_readable = _convert_to_human_readable(string)
+
+        self.assertEqual("Camel Case", human_readable)
+
+    def test_lower_case_to_human_readable(self):
+        string = "lower case"
+
+        human_readable = _convert_to_human_readable(string)
+
+        self.assertEqual("Lower Case", human_readable)
+
+    def test_upper_case_to_human_readable(self):
+        string = "UPPER CASE"
+
+        human_readable = _convert_to_human_readable(string)
+
+        self.assertEqual("Upper Case", human_readable)
+
+    def test_upper_case_with_underscore_to_human_readable(self):
+        string = "UPPER_CASE"
+
+        human_readable = _convert_to_human_readable(string)
+
+        self.assertEqual("Upper Case", human_readable)

--- a/sprout/tests/tests_views_metadata_create.py
+++ b/sprout/tests/tests_views_metadata_create.py
@@ -49,6 +49,23 @@ class FileUploadTests(TestCase):
         # Clean up
         FileMetadata.objects.first().delete()
 
+    def test_extracted_column_names_formats(self):
+        """Test for a table being created when csv is uploaded."""
+        # Arrange
+        create_table("Table Name").save()
+
+        file = self.create_file("file.csv", "DISPLAY_NAME,AGE\nPhil,36")
+
+        # Act
+        self.client.post("/metadata/create/1", {"uploaded_file": file})
+
+        # Assert
+        column = ColumnMetadata.objects.filter(extracted_name="DISPLAY_NAME").first()
+        self.assertEqual("Display Name", column.display_name)
+        self.assertEqual("display_name", column.machine_readable_name)
+        # Clean up
+        FileMetadata.objects.first().delete()
+
     def test_upload_failed_with_wrong_file_extension(self):
         """Test for error message when file is not ending on .csv."""
         create_table("Table Name").save()


### PR DESCRIPTION
## Description

- This PR formats ColumnMetadata.display_name to a more human friendly name. This makes it easier for the user to distinguish between display_name and extracted_name
- And I have also removed machine_readable_name from the table view.

(I thought this was relevant to fix before the demo)

![image](https://github.com/seedcase-project/seedcase-sprout/assets/5868902/10f4c1d5-6cb8-4c62-8796-9d5ac6c079d5)


![image](https://github.com/seedcase-project/seedcase-sprout/assets/5868902/46f2f110-5c5b-4d8b-9211-8c33d43dd3a3)

![image](https://github.com/seedcase-project/seedcase-sprout/assets/5868902/598e52fa-5de1-4427-b1bd-814034291fd1)



## Related Issues

<!-- List issues the PR closes -->

Closes #339, Closes #357 

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->

See also Issues #...

## Testing

- [X] Yes
- [ ] No, not needed (give a reason below)
- [ ] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
This PR only needs a quick review.

## Checklist

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
