### PR TITLE
fix: :zap: change normal strings to raw strings for regex patterns

### DIFF
--- a/sprout/models/columns.py
+++ b/sprout/models/columns.py
@@ -57,7 +57,7 @@ def _convert_to_snake_case(string: str) -> str:
     altered_string = string.strip()
 
     # Remove non-alphanumeric characters
-    altered_string = sub("[^a-zA-Z0-9\s_-]+", "", altered_string)
+    altered_string = sub(r"[^a-zA-Z0-9\s_-]+", "", altered_string)
 
     # Replace spaces and hyphens with underscores
     altered_string = sub(r"[\s-]+", "_", altered_string)
@@ -92,7 +92,7 @@ def _convert_to_human_readable(string: str) -> str:
     string = sub("_", " ", string)
 
     # Add space to CamelCase names
-    string = sub("([a-z])([A-Z])", r"\g<1> \g<2>", string)
+    string = sub(r"([a-z])([A-Z])", r"\g<1> \g<2>", string)
 
     # Capitalize first letter in words
     return string.title()


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR changes normal strings (`""`) to raw strings (`r""`) when they contain a regex to ensure that the regex is interpreted correctly by Python (an extension in VSCode complained about the escape character `\s` which is why I noticed it).

## Testing

- [X] No, not needed (give a reason below)

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
