### PR TITLE
refactor: make projects_id_metadata_view the home page

### DIFF
--- a/sprout/templates/projects-id-metadata-id-data-update.html
+++ b/sprout/templates/projects-id-metadata-id-data-update.html
@@ -20,7 +20,7 @@
           <span>Successfully uploaded <code class="file-ext">{{ file_metadata.original_file_name }}</code> and added {{ number_rows }} to {{ table_name }}</span>
         </div>
         <!-- TODO: Should this be here or as a button below the drop zone? -->
-        <a href="/metadata" class="inverse-link">Return to data view</a>
+        <a href="/" class="inverse-link">Return to data view</a>
       </div>
     {% endif %}
   </div>

--- a/sprout/templates/projects-id-metadata-id-data-update.html
+++ b/sprout/templates/projects-id-metadata-id-data-update.html
@@ -20,7 +20,7 @@
           <span>Successfully uploaded <code class="file-ext">{{ file_metadata.original_file_name }}</code> and added {{ number_rows }} to {{ table_name }}</span>
         </div>
         <!-- TODO: Should this be here or as a button below the drop zone? -->
-        <a href="/" class="inverse-link">Return to data view</a>
+        <a href="{% url 'project-id-metadata-view' %}" class="inverse-link">Return to data view</a>
       </div>
     {% endif %}
   </div>

--- a/sprout/tests/tests_views_projects_id_metadata_id_update.py
+++ b/sprout/tests/tests_views_projects_id_metadata_id_update.py
@@ -61,7 +61,7 @@ class MetadataIDUpdateViewTest(TestCase):
         response = self.client.post(url, data, follow=True)
 
         # Assert the status code
-        self.assertRedirects(response, reverse("projects-id-view"))
+        self.assertRedirects(response, reverse("projects-id-metadata-view"))
 
     def test_create_sample_of_unique_values(self):
         """Test if correct sample values are created."""

--- a/sprout/urls.py
+++ b/sprout/urls.py
@@ -5,7 +5,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("", views.home, name="home"),
+    path("", views.projects_id_metadata_view, name="projects-id-metadata-view"),
     path(
         "metadata/<int:table_id>/data/update",
         views.projects_id_metadata_id_data_update,
@@ -21,11 +21,6 @@ urlpatterns = [
         "metadata/<int:table_id>/update",
         views.projects_id_metadata_id_update,
         name="projects-id-metadata-id-update",
-    ),
-    path(
-        "metadata",
-        views.projects_id_metadata_view,
-        name="projects-id-metadata-view",
     ),
     path(
         "table-files/<int:table_id>",

--- a/sprout/views/__init__.py
+++ b/sprout/views/__init__.py
@@ -9,15 +9,3 @@ from .projects_id_metadata_id_update import projects_id_metadata_id_update
 from .projects_id_metadata_view import projects_id_metadata_view
 from .projects_id_view import projects_id_view
 from .table_files import table_file_download, table_files
-
-
-def home(request: HttpRequest) -> HttpResponse:
-    """Renders the Sprout landing page.
-
-    Args:
-        request: The HttpRequest from the user
-
-    Returns:
-        HttpResponse: HTML content for the landing page.
-    """
-    return render(request, "index.html")

--- a/sprout/views/projects_id_metadata_id_update.py
+++ b/sprout/views/projects_id_metadata_id_update.py
@@ -51,7 +51,7 @@ def projects_id_metadata_id_update(request: HttpRequest, table_id: int) -> HttpR
             if form.cleaned_data["excluded"]:
                 form.instance.delete()
 
-        return redirect(reverse("projects-id-view"))
+        return redirect(reverse("projects-id-metadata-view"))
 
     return render(
         request,


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR makes the `projects_id_metadata_view" the homepage and removes the placeholder homepage to follow the "alternative flow" that I have been working on.
- It also changes the url of this view from "metadata" to "". Thoughts?
- It also makes the view `view` (the one with the two large buttons "create new table" or "add data to existing table") unreachable. I thought that we might want to keep it if we want to use it later on? 

## Related Issues

<!-- List issues the PR closes -->

Closes #...

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->

See also Issues #...

## Testing

- [X] No, not needed (give a reason below)

Updated one existing test to fit the new redirect.

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated (none)
