### PR TITLE
fix: ⚡ to avoid having multiple tbodies, move <tbody> out of loop

### DIFF
--- a/sprout/templates/projects-id-metadata-view.html
+++ b/sprout/templates/projects-id-metadata-view.html
@@ -12,8 +12,8 @@
         <th>Last Upload</th>
       </tr>
     </thead>
+    <tbody>
     {% for metadata in existing_metadata %}
-      <tbody>
         <tr class="selectable" id="{{ metadata.id }}" onclick="rowSelected(event.target.parentElement)">
           <td>{{ metadata.name }}</td>
           <td>{{ metadata.description }}</td>
@@ -52,8 +52,8 @@
       {% empty %}
       <p>No existing metadata to show.</p>
     {% endfor %}
+    </tbody>
   </table>
-
   <!-- Create metadata dialog -->
   {% include 'includes/metadata-create-dialog.html' %}
 

--- a/sprout/templates/projects-id-metadata-view.html
+++ b/sprout/templates/projects-id-metadata-view.html
@@ -21,6 +21,7 @@
           <td>{{ metadata.data_rows }}</td>
           <td>{{ metadata.last_data_upload }}</td>
         </tr>
+        <tr>
         <!-- View metadata of all columns in the selected metadata -->
         <td colspan="6" class="metadata_columns_table" hidden id="{{ metadata.id }}">
           <table>
@@ -48,7 +49,7 @@
             </tbody>
           </table>
         </td>
-      </tbody>
+        </tr>
       {% empty %}
       <p>No existing metadata to show.</p>
     {% endfor %}


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR moves the `<tbody>` tag outside of the for-loop to avoid having so many tbodies. 
- In addition, it adds a `<tr>` around the `<td>` with the column metadata tables to make it more intuitive to read (it doesn't change the appearance in the browser). 

## Related Issues

<!-- List issues the PR closes -->

Closes #...

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->

See also Issues #...

## Testing

- [X] No, not needed (give a reason below)

Only minor changes to html. 

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [X] Tests accompany or reflect changes to the code
- [X] Tests ran and passed locally
- [X] Ran the linter and formatter
- [X] Build has passed locally
- [X] Relevant documentation has been updated
