### PR TITLE
fix: :bug: make --surface-container-high white so it's not purple

### DIFF
--- a/sprout/static/css/style.css
+++ b/sprout/static/css/style.css
@@ -15,7 +15,7 @@
   --surface-container-lowest: white;
   --on-surface-container-lowest: #6E6E6E;
   --surface-container-low: var(--surface-container-lowest);
-  --surface-container-high: var(--primary-container);
+  --surface-container-high: var(--surface-container-lowest);
   --outline-variant: #48DC76;
   --elevate1: 0 5px 10px rgba(0, 0, 0, 0.15);
 


### PR DESCRIPTION

## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR makes the theme variable `--surface-container-high` refer to `--surface-container-lowest` which is white. 
- Before it was purple (bc some default beercss, I think): 
![Screenshot 2024-04-29 at 10 12 36](https://github.com/seedcase-project/seedcase-sprout/assets/40836345/8376e4ab-0b2d-4d9d-82d7-b1bd5b17f95e)
- This applies to all of our dialogs/"pop up windows" and they now look have a white background instead:
![Screenshot 2024-04-29 at 10 56 04](https://github.com/seedcase-project/seedcase-sprout/assets/40836345/cf43bca2-481a-4ac4-9f2e-d654068147fe)


## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

Is this the "right" way to do this? To refer to another theme variable? Or is it better practice to make the variable white like this: `--surface-container-high: white;`? 
