### PR TITLE
fix: use url shortcode instead of urls inside a tags

### DIFF
--- a/sprout/templates/index.html
+++ b/sprout/templates/index.html
@@ -1,11 +1,12 @@
 {% extends 'includes/base.html' %}
-
 {% block content %}
   <div class="row center-align height-90-pct">
     <div>
       <h1>Welcome to Seedcase Sprout!</h1>
       <div class="center-align">
-        <a href="/view"><button>Get started</button></a>
+        <a href="{% url 'view' %}">
+          <button>Get started</button>
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR changes raw urls inside `<a>` tags to the Django URL shortcode. 
- I could only find one instance of this.

## Related Issues

<!-- List issues the PR closes -->

Closes #367 

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->

See also Issues #...

## Testing

Fails but bc of Django update