### PR TITLE
build: :wrench: set Fly option so it doesn't turn off too fast

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,10 @@
 
 app = "seedcase-sprout"
 primary_region = "ams"
+# Politely stop the process, rather than an abrupt close (default is SIGINT, signal interrupt).
+kill_signal = "SIGTERM"
+# Prevent the app from closing too early. Closes after 3 minutes.
+kill_timeout = 180
 
 [build]
 


### PR DESCRIPTION


## Description

These changes are done because Fly would turn off too soon (default is 5 seconds!!), because during demos, users take some time to look around and it ends up restarting... So this hopefully should fix that.

Closes #423

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review. Very small change!
