### PR TITLE
fix: 🐛 debug code depended on old unittest, updated for pytest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,17 @@
       "args": [
         "runserver"
       ]
+    },
+    {
+      "name": "test-debugger",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${file}",
+      "purpose": [
+        "debug-test"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": false
     }
   ]
 }

--- a/sprout/app/apps.py
+++ b/sprout/app/apps.py
@@ -25,7 +25,7 @@ class AppConfig(AppConfig):
         post_migrate.connect(update_data_types, sender=self)
 
         # Adding test data after migrate when DEBUG=TRUE and not running unit tests
-        is_not_running_unit_tests = "test" not in sys.argv
+        is_not_running_unit_tests = "pytest" not in sys.modules
         if DEBUG and is_not_running_unit_tests:
             post_migrate.connect(load_test_data, sender=self)
 


### PR DESCRIPTION
## Description

These changes fix failing tests by updating the way we check whether tests are running. This became out of date after switching to pytest. As a result, sample data was loaded into the test database, so tests checking if the `Files` table was empty were failing.

I've also added an extra test debug config allowing us to set breakpoints etc. in external files (e.g. library files or Django core code) -- feel free to ignore/change this.

Closes #523 

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Tests passed locally
- [x] Linted and formatted code
- [x] Build passed locally
- [x] Updated documentation 
