### PR TITLE
chore: 🔧 add sprout to included packages in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 homepage = "https://sprout.seedcase-project.org"
 repository = "https://github.com/seedcase-project/seedcase-sprout"
 license = "MIT"
+packages = [{include = "sprout"}]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/seedcase-project/seedcase-sprout/issues"


### PR DESCRIPTION
## Description

These changes are done to remove the warning/error we currently get when we run `poetry install`:

```
Installing the current project: seedcase-sprout (0.0.1)
The current project could not be installed: No file/folder found for package seedcase-sprout
If you do not want to install the current project use --no-root
```

DISCLAIMER: I'm not that familiar with poetry so I'm not sure this is the correct fix. However, I just looked at the [Basic usage example](https://python-poetry.org/docs/basic-usage/) in poetry's documentation and saw they had included `packages` under `[tool.poetry]` in the `pyproject.toml`. This seems to remove the warning/error.

Closes #

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a in-depth review.

## Checklist

I did none of the checks below for this PR.

- [ ] Added or updated tests
- [ ] Tests passed locally
- [ ] Linted and formatted code
- [ ] Build passed locally
- [ ] Updated documentation 
