### PR TITLE
fix: :fire: remove font colour and name from state diagrams

### DIFF
--- a/docs/design/images/core-python-functions/create-resource-properties.puml
+++ b/docs/design/images/core-python-functions/create-resource-properties.puml
@@ -1,9 +1,6 @@
 @startuml create-resource-properties
 !theme seedcase from https://raw.githubusercontent.com/seedcase-project/seedcase-theme/main
 
-skinparam StateFontColor black
-skinparam StateFontName Fira Code
-
 state "Input" as input {
   input : - `path_*()` functions assist with giving correct paths
 ' Arguments -----

--- a/docs/design/images/core-python-functions/create-resource-structure.puml
+++ b/docs/design/images/core-python-functions/create-resource-structure.puml
@@ -1,9 +1,6 @@
 @startuml create-resource-structure
 !theme seedcase from https://raw.githubusercontent.com/seedcase-project/seedcase-theme/main
 
-skinparam StateFontColor black
-skinparam StateFontName Fira Code
-
 state "Input" as input {
   input : - `path_*()` functions assist\n  with giving correct paths
 ' Arguments -----


### PR DESCRIPTION

## Description

These changes are done since:

- the font colour is already black in the puml theme
- I have added the font name to the theme here: seedcase-project/seedcase-theme#48


## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review. 

