### PR TITLE
feat: :sparkles: add `create_relative_resource_data_path()`

### DIFF
--- a/sprout/core/create_relative_resource_data_path.py
+++ b/sprout/core/create_relative_resource_data_path.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from re import split
 
 
 def create_relative_resource_data_path(path: Path) -> Path:
@@ -12,6 +11,4 @@ def create_relative_resource_data_path(path: Path) -> Path:
         Relative path from the package root to the resource data file
         E.g., "resources/1/data.parquet"
     """
-    relative_resource_path = split(r"packages/[0-9]*/", str(path))[1]
-
-    return Path(relative_resource_path) / "data.parquet"
+    return Path(*path.parts[-2:]) / "data.parquet"

--- a/sprout/core/create_relative_resource_data_path.py
+++ b/sprout/core/create_relative_resource_data_path.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from re import split
+
+
+def create_relative_resource_data_path(path: Path) -> Path:
+    """Create a relative path to the resource data file.
+
+    Args:
+        path: Absolute path to the folder of a specific resource
+
+    Returns:
+        Relative path from the package root to the resource data file
+        E.g., "resources/1/data.parquet"
+    """
+    relative_resource_path = split(r"packages/[0-9]*/", str(path))[1]
+
+    return Path(relative_resource_path) / "data.parquet"

--- a/tests/core/test_create_relative_resource_data_path.py
+++ b/tests/core/test_create_relative_resource_data_path.py
@@ -9,6 +9,7 @@ def test_returns_relative_path_with_single_digits(tmp_path):
     """Return the relative data path when package and resource ID are single digits."""
     tmp_path = tmp_path / "packages" / "1" / "resources" / "1"
     relative_path = Path("resources") / "1"
+
     assert (
         create_relative_resource_data_path(tmp_path) == relative_path / "data.parquet"
     )
@@ -18,6 +19,7 @@ def test_returns_relative_path_with_multi_digits(tmp_path):
     """Return the relative data path when package and resource ID are multi-digits."""
     tmp_path = tmp_path / "packages" / "100" / "resources" / "100"
     relative_path = Path("resources") / "100"
+
     assert (
         create_relative_resource_data_path(tmp_path) == relative_path / "data.parquet"
     )

--- a/tests/core/test_create_relative_resource_data_path.py
+++ b/tests/core/test_create_relative_resource_data_path.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from sprout.core.create_relative_resource_data_path import (
+    create_relative_resource_data_path,
+)
+
+
+def test_returns_relative_path_with_single_digits(tmp_path):
+    """Return the relative data path when package and resource ID are single digits."""
+    tmp_path = tmp_path / "packages" / "1" / "resources" / "1"
+    relative_path = Path("resources") / "1"
+    assert (
+        create_relative_resource_data_path(tmp_path) == relative_path / "data.parquet"
+    )
+
+
+def test_returns_relative_path_with_multi_digits(tmp_path):
+    """Return the relative data path when package and resource ID are multi-digits."""
+    tmp_path = tmp_path / "packages" / "100" / "resources" / "100"
+    relative_path = Path("resources") / "100"
+    assert (
+        create_relative_resource_data_path(tmp_path) == relative_path / "data.parquet"
+    )


### PR DESCRIPTION
## Description

Closes #575 

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review. Focus on:

- I have renamed the function from `path_relative_resource_data()` to `create_relative_resource_data_path()` to fit with the naming scheme. Thoughts? 
- This function actually does two things: 1) create a relative path to the resource and 2) add `data.parquet` to the path. Is this alright?


## Checklist

- [X] Added or updated tests
- [X] Tests passed locally
- [X] Linted and formatted code
- [X] Updated documentation (=docstrings)
