### PR TITLE
docs: :memo: add extract action to naming scheme

### DIFF
--- a/docs/design/naming.qmd
+++ b/docs/design/naming.qmd
@@ -62,5 +62,7 @@ specification.
 | write | Write an object to a file. |
 | copy | Copy a file from one location to another. |
 | delete | Permanently delete an object. |
+| verify | Compare against a standard, specifically the properties object against the specification. |
+| extract | Extract specific information from an object, specifically the properties from a data file. |
 
 : General actions that Sprout can take on objects or files/folders.

--- a/docs/design/naming.qmd
+++ b/docs/design/naming.qmd
@@ -62,7 +62,6 @@ specification.
 | write | Write an object to a file. |
 | copy | Copy a file from one location to another. |
 | delete | Permanently delete an object. |
-| verify | Compare against a standard, specifically the properties object against the specification. |
 | extract | Extract specific information from an object, specifically the properties from a data file. |
 
 : General actions that Sprout can take on objects or files/folders.


### PR DESCRIPTION
## Description

These changes are done to the naming scheme by adding an action: extract. This is because this is needed to be exposed by the Python package so that we can use it in the web app. More detail on how it will connect with the web app when I get to the design of the web app.

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review. 
