### PR TITLE
style: :art: run just format-python

### DIFF
--- a/sprout/core/verify_is_supported_format.py
+++ b/sprout/core/verify_is_supported_format.py
@@ -1,10 +1,24 @@
 from pathlib import Path
 
-SUPPORTED_FORMATS = ["csv", "tsv", "xlsx", "xls", "json", "jsonl", "ndjson", 
-                     "geojson", "topojson", "ods", "parq", "parquet"]
+SUPPORTED_FORMATS = [
+    "csv",
+    "tsv",
+    "xlsx",
+    "xls",
+    "json",
+    "jsonl",
+    "ndjson",
+    "geojson",
+    "topojson",
+    "ods",
+    "parq",
+    "parquet",
+]
+
 
 class UnsupportedFormatError(Exception):
     """Raised if file format is not supported by Sprout."""
+
     def __init__(self, format, *args, **kwargs):
         """Initialises UnsupportedFormatError.
 
@@ -16,8 +30,9 @@ class UnsupportedFormatError(Exception):
         message = (
             f"File format '{format}' is not supported. Sprout currently "
             f"supports the following formats: {', '.join(SUPPORTED_FORMATS)}."
-        )        
+        )
         super().__init__(message, *args, **kwargs)
+
 
 def verify_is_supported_format(path: Path) -> Path:
     """Checks that the format of the file given by the path is supported by Sprout.

--- a/tests/core/test_create_next_id.py
+++ b/tests/core/test_create_next_id.py
@@ -5,12 +5,14 @@ def test_create_next_id_creates_first_id_correctly():
     """Given no existing IDs, it should return 1."""
     assert create_next_id([]) == 1
 
+
 def test_create_next_id_creates_second_id_correctly():
     """Given one existing ID, it should return that ID + 1."""
     assert create_next_id([1]) == 2
 
+
 def test_create_next_id_creates_large_id_correctly():
-    """Given multiple, unordered, non-continuous existing IDs, 
+    """Given multiple, unordered, non-continuous existing IDs,
     it should return the biggest one + 1.
     """
     assert create_next_id([6, 333, 1, 45, 2, 3]) == 334


### PR DESCRIPTION
## Description

These changes are done to ensure the correct formatting of the python files using ruff. I just ran `just format-python`. 

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Tests passed locally
- [X] Linted and formatted code