### PR TITLE
chore: :children_crossing: limit functions accessible when importing all

### DIFF
--- a/sprout/core/__init__.py
+++ b/sprout/core/__init__.py
@@ -14,7 +14,7 @@
 # Resources -----
 # from .list_resources import *
 # from .view_resource import *
-from .create_resource_structure import *
+from .create_resource_structure import create_resource_structure
 
 # from .create_resource_properties import *
 # from .extract_resource_properties import *

--- a/sprout/core/__init__.py
+++ b/sprout/core/__init__.py
@@ -1,0 +1,87 @@
+"""Core, external-facing functions of Sprout."""
+# This exposes only the functions we want exposed when
+# the package is imported via `from sprout.core import *`.
+
+# Packages -----
+# from .list_packages import *
+# from .view_package_properties import *
+# from .create_package_structure import *
+# from .create_package_properties import *
+# from .edit_package_properties import *
+# from .write_package_properties import *
+# from .delete_package import *
+
+# Resources -----
+# from .list_resources import *
+# from .view_resource import *
+# from .create_resource_structure import *
+# from .create_resource_properties import *
+# from .extract_resource_properties import *
+# from .edit_resource_properties import *
+# from .write_resource_data_to_raw import *
+# from .write_resource_parquet import *
+# from .write_resource_properties import *
+# from .write_resource_to_database import *
+# from .delete_resource_raw_file import *
+# from .delete_resource_data import *
+# from .delete_resource_properties import *
+
+# Path -----
+# TODO: Consider having all these in one module.
+# from .path_resources import *
+# from .path_resource import *
+# from .path_resource_raw import *
+# from .path_resource_raw_files import *
+# from .path_resource_data import *
+# from .path_properties import *
+# from .path_package_database import *
+# from .path_package import *
+# from .path_sprout_root import *
+
+# Helpers -----
+# from .create_properties_template import *
+# from .pretty_json import *
+# from .view_properties import *
+# from .view_package_properties_template import *
+# from .view_resource_properties_template import *
+
+__all__ = [
+    # Packages -----
+    # "list_packages",
+    # "view_package_properties",
+    # "create_package_structure",
+    # "create_package_properties",
+    # "edit_package_properties",
+    # "write_package_properties",
+    # "delete_package",
+    # Resources -----
+    # "list_resources",
+    # "view_resource",
+    # "create_resource_structure",
+    # "create_resource_properties",
+    # "extract_resource_properties",
+    # "edit_resource_properties",
+    # "write_resource_data_to_raw",
+    # "write_resource_parquet",
+    # "write_resource_properties",
+    # "write_resource_to_database",
+    # "delete_resource_raw_file",
+    # "delete_resource_data",
+    # "delete_resource_properties",
+    # Path -----
+    # "path_resources",
+    # "path_resource",
+    # "path_resource_raw",
+    # "path_resource_raw_files",
+    # "path_resource_data",
+    # "path_properties",
+    # "path_package_database",
+    # "path_package",
+    # "path_sprout_root",
+    # Helpers -----
+    # "create_properties_template",
+    # "pretty_json",
+    # "view_properties",
+    # "view_package_properties_template",
+    # "view_resource_properties_template",
+]


### PR DESCRIPTION

## Description

These changes sets up the structure so that whenever `from sprout.core import *` is used, it only gives access to the functions we want. So far, I've only added commented code, but we can use this also as a nice visual to see our progress :tada:

Closes #533

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review. 

