### PR TITLE
docs: :memo: ensure WIP callout is always default appearance

### DIFF
--- a/docs/includes/_wip.qmd
+++ b/docs/includes/_wip.qmd
@@ -1,4 +1,4 @@
-::: callout-warning
+::: {.callout-warning appearance="default" icon="true"}
 🚧 This section is still in active development and is subject to changes
 🚧
 :::


### PR DESCRIPTION
## Description

These changes are done to make sure that the WIP callout block is always going to be default appearance, no matter what the local doc settings are. This came up when I was making the python code description more easily navigatable


## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review. 
