### PR TITLE
fix: :bug: fix import using old name

### DIFF
--- a/sprout/core/create_resource_properties.py
+++ b/sprout/core/create_resource_properties.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from sprout.core.create_relative_resource_data_path import (
     create_relative_resource_data_path,
 )
-from sprout.core.edit_resource_properties_field import edit_resource_properties_field
+from sprout.core.edit_property_field import edit_property_field
 from sprout.core.verify_is_dir import verify_is_dir
 from sprout.core.verify_resource_properties import verify_resource_properties
 
@@ -35,4 +35,4 @@ def create_resource_properties(path: Path, properties: dict) -> dict:
     verify_is_dir(path)
     verify_resource_properties(properties)
     data_path = create_relative_resource_data_path(path)
-    return edit_resource_properties_field(properties, "path", str(data_path))
+    return edit_property_field(properties, "path", str(data_path))


### PR DESCRIPTION
## Description

This fixes an import that was using an old function name. I think it got there because first the rename PR was merged and then the PR that used the old name.

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review. 

## Checklist

- [x] Added or updated tests
- [x] Tests passed locally
- [x] Linted and formatted code
- [x] Build passed locally
- [x] Updated documentation 
