### PR TITLE
docs: :memo: replace `view_*_template()` with `*Properties`

### DIFF
--- a/docs/design/architecture/naming.qmd
+++ b/docs/design/architecture/naming.qmd
@@ -44,7 +44,6 @@ We may also occasionally use "properties" to refer to the file itself.
 | properties or property | Metadata about a package or resource. |
 | file structure or structure | The file and folder structure of a package. |
 | path | A file path listing the location of folders or files that Sprout interacts with. |
-| template | A template file for specific objects, such as a template for a package or resource properties file. |
 | data | The data file within a resource. Within Sprout, this includes the table in the database, the Parquet file, as well as raw files. |
 | identifier | A unique identifier for a package or resource, denoted as `id`. |
 

--- a/docs/design/implementation/python-functions.qmd
+++ b/docs/design/implementation/python-functions.qmd
@@ -201,7 +201,7 @@ This function sets up and structures a new resource property by taking
 the fields given in the `properties` argument to fill them and prepare
 them to be added to the `datapackage.json` file. It must be given as a
 JSON object following the Data Package specification (use
-`view_resource_properties_template()` to get a JSON object that follows
+the `ResourceProperties` class to get an object that follows
 the Frictionless Data Package standard). The `path` argument provides
 the path to the resource `id` that the properties are for; use
 `path_resource()` to provide the correct path or use the output of

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -98,9 +98,8 @@ sp.write_package_properties(
 )
 ```
 
-If you need help with filling in the right properties, use
-`view_package_properties_template()` to see the available fields to fill
-in.
+If you need help with filling in the right properties, see the documentation
+on `PackageProperties` to see what fields could or should be filled in.
 
 You now have the basic starting point for adding data resources to your
 data package.

--- a/sprout/core/create_resource_properties.py
+++ b/sprout/core/create_resource_properties.py
@@ -21,8 +21,9 @@ def create_resource_properties(path: Path, properties: dict) -> dict:
             `create_resource_structure()`.
         properties: the properties of the resource; must be given as a
             JSON object following the Data Package specification; use
-            `view_resource_properties_template()` to get a JSON object
-            that follows the Frictionless Data Package standard.
+            the `ResourceProperties` class to provide the correct fields.
+            See the `ResourceProperties` help documentation for details
+            on what can or needs to be filled in.
 
     Raises:
         NotADirectoryError: if path does not point to a directory.


### PR DESCRIPTION
## Description

These changes remove the documentation on `view_*_properties_template()`, since this can be achieved with `*Properties` class objects now. 

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

