### PR TITLE
feat: ✨ add `path_*()` functions Including helper functions

### DIFF
--- a/sprout/core/path_helper_functions.py
+++ b/sprout/core/path_helper_functions.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from sprout.core.get_ids import get_ids
+from sprout.core.verify_is_dir import verify_is_dir
+from sprout.core.verify_is_file import verify_is_file
+
+
+def verify_is_dir_or_raise_error_with_id_context(path: Path, ids_path: Path):
+    """Verifies if path is a directory or raises error with existing ids.
+
+    Args:
+        path: Path to verify.
+        ids_path: Path to find existing ID's.
+
+    Returns:
+        Path, if path is a directory.
+
+    Raises:
+        NotADirectoryError: If the path is not a directory. The error message
+            includes existing ID's.
+    """
+    try:
+        verify_is_dir(path)
+        return path
+    except NotADirectoryError as e:
+        existing_ids = get_ids(ids_path)
+        raise NotADirectoryError(f"Existing ID's are {existing_ids}") from e
+
+
+def verify_is_file_or_raise_error_with_id_context(path: Path, ids_path: Path):
+    """Verifies if path is a file or raises error with existing ids.
+
+    Args:
+        path: Path to verify.
+        ids_path: Path to find existing ID's.
+
+    Returns:
+        Path, if path is a file.
+
+    Raises:
+        FileNotFoundError: If the path is not a file. The error message
+            includes existing ID's.
+    """
+    try:
+        verify_is_file(path)
+        return path
+    except FileNotFoundError as e:
+        existing_ids = get_ids(ids_path)
+        raise FileNotFoundError(f"Existing ID's are {existing_ids}") from e

--- a/sprout/core/path_package_functions.py
+++ b/sprout/core/path_package_functions.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from sprout.core.path_helper_functions import (
+    verify_is_dir_or_raise_error_with_id_context,
+    verify_is_file_or_raise_error_with_id_context,
+)
+from sprout.core.path_sprout_root import path_sprout_root
+from sprout.core.verify_is_dir import verify_is_dir
+
+
+def path_package(package_id: int) -> Path:
+    """Gets the absolute path to the specific package folder.
+
+    Args:
+        package_id: The ID of the package to get the folder path for.
+
+    Returns:
+        The absolute path to the package folder.
+    """
+    path = path_sprout_root() / "packages" / str(package_id)
+    return verify_is_dir_or_raise_error_with_id_context(path=path, ids_path=path.parent)
+
+
+def path_package_database(package_id: int) -> Path:
+    """Gets the absolute path to a given package's SQL database.
+
+    Args:
+        package_id: ID of the package.
+
+    Returns:
+        A Path to the package's database.
+    """
+    path = path_sprout_root() / "packages" / str(package_id) / "database.sql"
+    return verify_is_file_or_raise_error_with_id_context(
+        path=path, ids_path=path.parent.parent
+    )
+
+
+def path_package_properties(package_id: int) -> Path:
+    """Gets the absolute path to a given package's properties file.
+
+    Args:
+        package_id: ID of the package.
+
+    Returns:
+        A Path to the properties file.
+    """
+    path = path_sprout_root() / "packages" / str(package_id) / "datapackage.json"
+    return verify_is_file_or_raise_error_with_id_context(
+        path=path, ids_path=path.parent.parent
+    )
+
+
+def path_packages() -> Path:
+    """Gets the absolute path to the packages folder.
+
+    Returns:
+        A Path to the packages folder.
+
+    Raises:
+        NotADirectoryError: If the packages folder doesn't exist.
+    """
+    return verify_is_dir(path_sprout_root() / "packages")
+    #     return path
+    # except NotADirectoryError as e:
+    #     raise NotADirectoryError(
+    #         "It seems that the `packages` folder doesn't exist yet"
+    #     ) from e

--- a/sprout/core/path_resource_functions.py
+++ b/sprout/core/path_resource_functions.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+
+from sprout.core.get_ids import get_ids
+from sprout.core.path_helper_functions import (
+    verify_is_dir_or_raise_error_with_id_context,
+    verify_is_file_or_raise_error_with_id_context,
+)
+from sprout.core.path_sprout_root import path_sprout_root
+from sprout.core.verify_is_dir import verify_is_dir
+
+
+def path_resource(package_id: int, resource_id: int) -> Path:
+    """Gets the absolute path to a given resource of a given package.
+
+    Args:
+        package_id: ID of the package.
+        resource_id: ID of the resource.
+
+    Returns:
+        A Path to the resource.
+    """
+    path = (
+        path_sprout_root()
+        / "packages"
+        / str(package_id)
+        / "resources"
+        / str(resource_id)
+    )
+    return verify_is_dir_or_raise_error_with_id_context(path=path, ids_path=path.parent)
+
+
+def path_resource_data(package_id: int, resource_id: int) -> Path:
+    """Gets the absolute path to a given resource's data (i.e., parquet) file.
+
+    Args:
+        package_id: ID of the package.
+        resource_id: ID of the resource.
+
+    Returns:
+        A Path to the resource's data file.
+    """
+    path = (
+        path_sprout_root()
+        / "packages"
+        / str(package_id)
+        / "resources"
+        / str(resource_id)
+        / "data.parquet"
+    )
+    return verify_is_file_or_raise_error_with_id_context(
+        path=path, ids_path=path.parent.parent
+    )
+
+
+def path_resource_raw(package_id: int, resource_id: int) -> Path:
+    """Gets the absolute path to a given resource's raw folder.
+
+    Args:
+        package_id: ID of the package.
+        resource_id: ID of the resource.
+
+    Returns:
+        A Path to the resource's raw folder.
+    """
+    path = (
+        path_sprout_root()
+        / "packages"
+        / str(package_id)
+        / "resources"
+        / str(resource_id)
+        / "raw"
+    )
+    return verify_is_dir_or_raise_error_with_id_context(
+        path=path, ids_path=path.parent.parent
+    )
+
+
+def path_resource_raw_files(package_id: int, resource_id: int) -> list[Path]:
+    """Gets the absolute path to the raw files of  a resource.
+
+    Args:
+        package_id: ID of the package.
+        resource_id: ID of the resource.
+
+    Returns:
+        A list of Paths to the raw files of the resource.
+
+    Raises:
+        NotADirectoryError: If the package_id doesn't exist or the resource_id doesn't
+            exist within the package.
+    """
+    path = (
+        path_sprout_root()
+        / "packages"
+        / str(package_id)
+        / "resources"
+        / str(resource_id)
+        / "raw"
+    )
+
+    try:
+        verify_is_dir(path)
+        return [file for file in path.iterdir()]
+    except NotADirectoryError as e:
+        raise NotADirectoryError(
+            f"Existing ID's are {get_ids(path.parent.parent)}"
+        ) from e
+
+
+def path_resources(package_id: int) -> Path:
+    """Gets the absolute path to resources of a given package.
+
+    Args:
+        package_id: ID of the package to get the resource path from."
+
+    Returns:
+        A Path to the resources within the package.
+    """
+    path = path_sprout_root() / "packages" / str(package_id) / "resources"
+    return verify_is_dir_or_raise_error_with_id_context(path, path.parent.parent)

--- a/tests/core/path_function_test_utils.py
+++ b/tests/core/path_function_test_utils.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+
+def create_test_package_structure(root_path: Path, package_id: int):
+    """Creates a package file structure (with empty files) for path function tests.
+
+    Args:
+        root_path: Root path to create the package structure.
+        package_id: ID of the package to create.
+
+    Returns:
+        Path of package.
+    """
+    path_package = root_path / "packages" / str(package_id)
+    path_package.mkdir(parents=True)
+    (path_package / "datapackage.json").touch()
+    (path_package / "database.sql").touch()
+    return path_package
+
+
+def create_test_resource_structure(
+    package_path: Path, resource_id: int, raw_files: list[str]
+):
+    """Creates a resource file structure (with empty files) for path function tests.
+
+    Args:
+        package_path: Path to package.
+        resource_id: ID of the resource to create.
+        raw_files: Name(s) of raw file(s).
+
+    Returns:
+        _description_.
+    """
+    path_resource = package_path / "resources" / str(resource_id)
+    (path_resource / "raw").mkdir(parents=True)
+    (path_resource / "data.parquet").touch()
+    for raw_file in raw_files:
+        (path_resource / "raw" / raw_file).touch()
+    return path_resource

--- a/tests/core/test_path_package_functions.py
+++ b/tests/core/test_path_package_functions.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from re import escape
+
+from pytest import fixture, mark, raises
+
+from sprout.core.path_package_functions import (
+    path_package,
+    path_package_database,
+    path_package_properties,
+    path_packages,
+)
+from tests.core.path_function_test_utils import (
+    create_test_package_structure,
+)
+
+
+# Given one package
+@fixture
+def tmp_sprout_root(monkeypatch, tmp_path):
+    """Set up test package folder structure and return temp root directory"""
+    SPROUT_ROOT = str(tmp_path)
+    monkeypatch.setenv("SPROUT_ROOT", SPROUT_ROOT)
+    create_test_package_structure(tmp_path, "1")
+
+    return SPROUT_ROOT
+
+
+@mark.parametrize(
+    "function, expected_path",
+    [
+        (path_package, "packages/1"),
+        (path_package_database, "packages/1/database.sql"),
+        (path_package_properties, "packages/1/datapackage.json"),
+    ],
+)
+def test_path_package_functions_return_expected_path(
+    tmp_sprout_root, function, expected_path
+):
+    # When, then
+    assert function(package_id=1) == Path(tmp_sprout_root) / expected_path
+
+
+@mark.parametrize(
+    "function, expected_exception",
+    [
+        (path_package, NotADirectoryError),
+        (path_package_database, FileNotFoundError),
+        (path_package_properties, FileNotFoundError),
+    ],
+)
+def test_path_package_functions_raise_error_if_package_id_does_not_exist(
+    tmp_sprout_root, function, expected_exception
+):
+    # When, then
+    with raises(expected_exception, match=escape("[1]")):
+        function(package_id=2)
+
+
+def test_path_packages_returns_expected_path(tmp_sprout_root):
+    # When, then
+    assert path_packages() == Path(tmp_sprout_root) / "packages"
+
+
+def test_path_packages_raises_error_when_no_packages_exist():
+    # When, then
+    with raises(NotADirectoryError):
+        path_packages()

--- a/tests/core/test_path_resource_functions.py
+++ b/tests/core/test_path_resource_functions.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+from re import escape
+
+from pytest import fixture, mark, raises
+
+from sprout.core.path_resource_functions import (
+    path_resource,
+    path_resource_data,
+    path_resource_raw,
+    path_resource_raw_files,
+    path_resources,
+)
+from tests.core.path_function_test_utils import (
+    create_test_package_structure,
+    create_test_resource_structure,
+)
+
+
+# Given a package with two resources
+@fixture
+def tmp_sprout_root(monkeypatch, tmp_path):
+    """Set up test package folder structure return temp root directory"""
+    SPROUT_ROOT = str(tmp_path)
+    monkeypatch.setenv("SPROUT_ROOT", SPROUT_ROOT)
+
+    path_package_1 = create_test_package_structure(tmp_path, "1")
+    create_test_resource_structure(path_package_1, "1", ["raw_file_1.csv.gz"])
+    create_test_resource_structure(
+        path_package_1, "2", ["raw_file_2.csv.gz", "raw_file_3.csv.gz"]
+    )
+
+    return SPROUT_ROOT
+
+
+@mark.parametrize(
+    "function, expected_path",
+    [
+        (path_resource, "packages/1/resources/2"),
+        (path_resource_data, "packages/1/resources/2/data.parquet"),
+        (path_resource_raw, "packages/1/resources/2/raw"),
+    ],
+)
+def test_path_resource_functions_return_expected_path(
+    tmp_sprout_root, function, expected_path
+):
+    # When, then
+    assert (
+        function(package_id=1, resource_id=2) == Path(tmp_sprout_root) / expected_path
+    )
+
+
+def test_path_resources_returns_expected_path(tmp_sprout_root):
+    # When, then
+    assert (
+        path_resources(package_id=1)
+        == Path(tmp_sprout_root) / "packages" / "1" / "resources"
+    )
+
+
+def test_path_resource_raw_files_returns_expected_list_of_paths(tmp_sprout_root):
+    # When
+    resource_raw_path = (
+        Path(tmp_sprout_root) / "packages" / "1" / "resources" / "2" / "raw"
+    )
+    # Then
+    assert set(path_resource_raw_files(package_id=1, resource_id=2)) == set(
+        [
+            resource_raw_path / "raw_file_2.csv.gz",
+            resource_raw_path / "raw_file_3.csv.gz",
+        ]
+    )
+
+
+@mark.parametrize(
+    "function, expected_exception",
+    [
+        (path_resource, NotADirectoryError),
+        (path_resource_data, FileNotFoundError),
+        (path_resource_raw, NotADirectoryError),
+        (path_resource_raw_files, NotADirectoryError),
+    ],
+)
+def test_path_resource_functions_raise_error_if_res_id_does_not_exist(
+    tmp_sprout_root, function, expected_exception
+):
+    """Raises error if package ID exists but resource ID does not"""
+    # When, then
+    with raises(expected_exception, match=escape("[1, 2]")):
+        function(package_id=1, resource_id=3)
+
+
+@mark.parametrize(
+    "function, expected_exception",
+    [
+        (path_resource, NotADirectoryError),
+        (path_resource_data, FileNotFoundError),
+        (path_resource_raw, NotADirectoryError),
+        (path_resource_raw_files, NotADirectoryError),
+    ],
+)
+def test_raises_error_if_package_id_does_not_exist(
+    tmp_sprout_root, function, expected_exception
+):
+    """Raises error if package ID doesn't exist but resource ID does
+    in another package"""
+    # When, then
+    with raises(expected_exception, match=escape("[]")):
+        function(package_id=2, resource_id=1)
+
+
+def test_path_resources_raises_error_when_package_does_not_exist(tmp_sprout_root):
+    # When, then
+    with raises(NotADirectoryError, match=escape("[1]")):
+        path_resources(package_id=2)


### PR DESCRIPTION
## Description

I decided to have a script for path functions related to packages and one related to resources. I found that it became too long - for my taste at least - with the docstrings otherwise. 

To add existing ID's to the raised errors, I have added two helper functions in the `path_helper_functions()`. 



Closes #714 

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

Focus on CHANGES.

## Checklist

- [ ] Added or updated tests
- [ ] Tests passed locally
- [ ] Linted and formatted code
- [ ] Build passed locally
- [ ] Updated documentation
