### PR TITLE
feat: :sparkles: add `read_json()`

### DIFF
--- a/sprout/core/read_json.py
+++ b/sprout/core/read_json.py
@@ -1,0 +1,17 @@
+from json import loads
+from pathlib import Path
+
+
+def read_json(path: Path) -> list | dict:
+    """Loads the contents of a JSON file into an object.
+
+    Args:
+        path: The path to the file to load.
+
+    Returns:
+        The contents of the file as an object.
+
+    Raises:
+        JSONDecodeError: If the contents of the file cannot be deserialised as JSON.
+    """
+    return loads(path.read_text())

--- a/tests/core/test_read_json.py
+++ b/tests/core/test_read_json.py
@@ -1,0 +1,46 @@
+from json import JSONDecodeError
+from pathlib import Path
+
+from pytest import mark, raises
+
+from sprout.core.read_json import read_json
+from sprout.core.write_json import write_json
+
+
+@mark.parametrize(
+    "expected",
+    [
+        {},
+        [],
+        {
+            "outer": "value",
+            "inner": {"prop1": 123, "prop2": [1, 2, None], "prop3": True},
+        },
+        [{"prop1": "value"}, {"prop2": 123}],
+    ],
+)
+def test_reads_valid_file(tmp_path, expected):
+    """Should load the contents of a deserialisable JSON file into an object."""
+    tmp_path = tmp_path / "test.json"
+    write_json(expected, tmp_path)
+
+    assert read_json(tmp_path) == expected
+
+
+def test_rejects_empty_file(tmp_path):
+    """Should reject an empty file."""
+    tmp_path = tmp_path / "test.json"
+    tmp_path.touch()
+
+    with raises(JSONDecodeError):
+        read_json(tmp_path)
+
+
+@mark.parametrize("contents", [True, None, "test", {"path": Path("test")}])
+def test_rejects_invalid_file(tmp_path, contents):
+    """Should reject a file whose contents are not deserialisable as JSON."""
+    tmp_path = tmp_path / "test.json"
+    tmp_path.write_text(str(contents))
+
+    with raises(JSONDecodeError):
+        read_json(tmp_path)


### PR DESCRIPTION
## Description

This adds a simple `read_json()` function, which loads the contents of a JSON file into a dictionary / list.
This is basically the `read_properties` function without any properties-specific validation. This way, it's not tied to the `datapackage.json` file in any way, so I used a more general name. If we do want to add properties-specific validation, we can still build on this function.

Not sure if closes but related to #711 

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.


## Checklist

- [x] Added or updated tests
- [x] Tests passed locally
- [x] Linted and formatted code
- [x] Build passed locally
- [x] Updated documentation
