### PR TITLE
docs: :memo: description of split between core, cli, and app

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,7 +1,7 @@
 project:
   type: seedcase-theme
   render:
-    - "docs/*" 
+    - "docs/*"
     - "index.qmd"
 
 website:
@@ -39,6 +39,7 @@ website:
             - docs/design/architecture/requirements.qmd
             - docs/design/architecture/c4-models.qmd
             - docs/design/architecture/naming.qmd
+            - docs/design/architecture/modular-design.qmd
             - docs/design/architecture/user-roles.qmd
         - section: "Implementation"
           href: docs/design/implementation/index.qmd

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -19,14 +19,14 @@ exposed to the user and to other programs.
 
 Any extensions would then only need to incorporate and depend on the
 `sprout.core` package to get Sprout's functionality. Each extension
-would be it's own module within Sprout, with modules named like
+would be its own module within Sprout, with modules named like
 `sprout/extension_name/`, for instance, `sprout/cli/`. That way, within
 the extension's module, the logic that we implement is only specific to
-creating the CLI and not with the actual functionality of Sprout.
+creating the CLI and not to the actual functionality of Sprout.
 
 Other potential extensions would follow the same or similar pattern.
 This allows other developers to create their own extensions and
-interfaces with Sprout that suit their particular needs.
+interfaces to Sprout that suit their particular needs.
 
 Our [Guide](/guide/index.qmd) has examples and tutorials on how each
 split is used.
@@ -41,7 +41,7 @@ split is used.
     Python packages that convert that code into a web app.
 
 -   The web API is in `sprout/api/`. Each endpoint imports the required
-    functions from `sprout.core` and converted into a web API form using
+    functions from `sprout.core` with
     functions from other Python packages that convert that code into a
     web API. This particular module may not be necessary as many Python
     packages that create web apps are also able to easily create web

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -1,0 +1,48 @@
+---
+title: "Modular design"
+---
+
+While we describe how we implement aspects of modular design across all
+Seedcase products in our [design
+documentation](https://design.seedcase-project.org), this document
+explains this split between Python code, CLI, web app, and web API in
+the context of Sprout.
+
+## Python modules
+
+In order to achieve our aims, the main functionality is designed and
+implemented as a Python package and can be used as a Python package.
+This code is stored in the Python module (folder location)
+`sprout/core/` and is accessible via the Python code
+`import sprout.core` statement. Only external-facing functions would be
+exposed to the user and to other programs.
+
+Any extensions would then only need to incorporate and depend on the
+`sprout.core` package to get Sprout's functionality. Each extension
+would be it's own module within Sprout, with modules named like
+`sprout/extension_name/`, for instance, `sprout/cli/`. That way, within
+the extension's module, the logic that we implement is only specific to
+creating the CLI and not with the actual functionality of Sprout.
+
+Other potential extensions would follow the same or similar pattern.
+This allows other developers to create their own extensions and
+interfaces with Sprout that suit their particular needs.
+
+Our [Guide](/guide/index.qmd) has examples and tutorials on how each
+split is used.
+
+-   For our CLI, it is placed in the module `sprout/cli/`. Each command
+    imports the relevant functions from `sprout.core`, along with
+    decorators (from other Python packages) to convert the Python code
+    into a CLI program.
+
+-   The web app is in `sprout/app/`. Each page of the web app imports
+    the required functions from `sprout.core`, with functions from other
+    Python packages that convert that code into a web app.
+
+-   The web API is in `sprout/api/`. Each endpoint imports the required
+    functions from `sprout.core` and converted into a web API form using
+    functions from other Python packages that convert that code into a
+    web API. This particular module may not be necessary as many Python
+    packages that create web apps are also able to easily create web
+    APIs from the same or slightly modified code.


### PR DESCRIPTION
## Description

Add a document description the split between core, CLI, and App (plus API).

Closes #675

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a fairly quick review.

