### PR TITLE
style: :art: move WIP header into Quarto config, rather than as own file

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -11,9 +11,9 @@ website:
   page-navigation: true
   body-header: |
     ::: {.callout-warning appearance="default" icon="true"}
-    🚧 Sprout is still in very active development and is evolving quickly, so
-    documentation and functionality may or may not work as described or intended
-    and could have substantial changes 🚧
+    🚧 Sprout is still in active development and evolving quickly, so the
+    documentation and functionality may not work as described
+    and could undergo substantial changes 🚧
     :::
   navbar:
     pinned: true

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,6 +9,12 @@ website:
   site-url: "https://sprout.seedcase-project.org/"
   repo-url: "https://github.com/seedcase-project/seedcase-sprout"
   page-navigation: true
+  body-header: |
+    ::: {.callout-warning appearance="default" icon="true"}
+    🚧 Sprout is still in very active development and is evolving quickly, so
+    documentation and functionality may or may not work as described or intended
+    and could have substantial changes 🚧
+    :::
   navbar:
     pinned: true
     title: false

--- a/docs/design/architecture/data-types.qmd
+++ b/docs/design/architecture/data-types.qmd
@@ -2,8 +2,6 @@
 title: Data Types Used
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 When defining a table before uploading the data, the data types must be
 chosen from a pre-defined list of data types. These are a subset of the
 all possible data types that are available to most database systems,

--- a/docs/design/architecture/index.qmd
+++ b/docs/design/architecture/index.qmd
@@ -2,10 +2,8 @@
 title: "Design of Sprout"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 This documentation contains the design specific to Sprout, for design
-of the Seedcase platform, see the [Design](https://design.seedcase-project.org) 
+of the Seedcase platform, see the [Design](https://design.seedcase-project.org)
 documentation.
 
 ## Purpose
@@ -18,7 +16,7 @@ to accomplish and how it will do that.
 
 ![[C4 Context diagram](https://c4model.com/#SystemContextDiagram)
 showing users and external systems that connect to the Data Resource
-managed by Seedcase.](images/c4/context.svg) 
+managed by Seedcase.](images/c4/context.svg)
 
 ## Goals
 

--- a/docs/design/architecture/naming.qmd
+++ b/docs/design/architecture/naming.qmd
@@ -2,8 +2,6 @@
 title: "Naming scheme"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 This document describes a general naming scheme for Sprout that is
 guided by our [style guide](https://design.seedcase-project.org/style/)
 as well as by the [Frictionless

--- a/docs/design/architecture/requirements.qmd
+++ b/docs/design/architecture/requirements.qmd
@@ -2,8 +2,6 @@
 title: "Requirements"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 ## Technical requirements
 
 -   Run on Windows, MacOS, and Linux (likely on servers): Our potential

--- a/docs/design/architecture/user-flow.qmd
+++ b/docs/design/architecture/user-flow.qmd
@@ -2,8 +2,6 @@
 title: User Flow
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 This document describes the user flow of Sprout. The user flow is split
 into five diagrams that go through the flow in more detail. At the end
 of the document, you can see the user flow of Sprout in its entirety.

--- a/docs/design/architecture/user-roles.qmd
+++ b/docs/design/architecture/user-roles.qmd
@@ -2,8 +2,6 @@
 title: User roles and permissions
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 There are three roles given to users: Project owner, project
 administrator (or project admin), and data contributor. Each role comes
 with a set of permissions that give access to different actions within

--- a/docs/design/implementation/app-urls.qmd
+++ b/docs/design/implementation/app-urls.qmd
@@ -2,8 +2,6 @@
 title: "Web App URLs and Functionality"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 Based on the [naming scheme](/docs/design/architecture/naming.qmd), this document describes the
 core, user-facing web app URLs and functionality provided within
 `sprout/app/`. See the [outputs](outputs.qmd) document for an overview
@@ -15,7 +13,7 @@ URLs:
     use plural nouns like `packages` and `resources` since they
     represent a collection of items traditionally shown in a folder or
     list view. For instance, `packages/` is the URL/folder that contains
-    all the packages, but `packages/1/` is the folder for the package 
+    all the packages, but `packages/1/` is the folder for the package
     with the ID of 1.
 2.  Since the default action for viewing a list of items or
     details of a specific item are the same, unlike for the Python functions
@@ -66,9 +64,9 @@ Following these principles, the URLs would be:
 
 :   Create a new resource for data and associated properties. The user
     can upload a file with data, which will be used to extract some
-    basic properties. The user will then be prompted to fill in the remaining 
-    properties and validate the extracted properties. When this is done, the 
-    properties are completed and created. The user can continue to edit the 
+    basic properties. The user will then be prompted to fill in the remaining
+    properties and validate the extracted properties. When this is done, the
+    properties are completed and created. The user can continue to edit the
     resource after creation.
 
 `packages/<id>/resources/<id>`
@@ -94,5 +92,5 @@ Following these principles, the URLs would be:
 
 `packages/<id>/resources/<id>/delete`
 
-:   Delete all associated data and properties of a specific resource. 
+:   Delete all associated data and properties of a specific resource.
     This is permanent, so the user will be asked to confirm the deletion.

--- a/docs/design/implementation/index.qmd
+++ b/docs/design/implementation/index.qmd
@@ -2,8 +2,6 @@
 title: "Implementation"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 This section of the documentation focuses on how the architectural
 design will be implemented. It is split into the following set of
 documents:

--- a/docs/design/implementation/outputs.qmd
+++ b/docs/design/implementation/outputs.qmd
@@ -2,8 +2,6 @@
 title: "Outputs"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 Sprout is designed to structure, organize, and store data in a
 standardized, coherent, and consistent way. At the base of how data is
 structured and stored are the files and folders. So, this document

--- a/docs/design/implementation/python-functions.qmd
+++ b/docs/design/implementation/python-functions.qmd
@@ -4,8 +4,6 @@ callout-icon: false
 callout-appearance: "minimal"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 ::: {.callout-important appearance="default" icon="true"}
 We created this document, and especially the function diagrams, mainly
 as a way to help us as a team all understand and agree on what we're

--- a/docs/design/index.qmd
+++ b/docs/design/index.qmd
@@ -2,8 +2,6 @@
 title: "Design of Sprout"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 Within the design documentation are two main sections:
 
 -   [Architecture](architecture/index.qmd): The architecture section

--- a/docs/guide/index.qmd
+++ b/docs/guide/index.qmd
@@ -3,4 +3,3 @@ title: "Guide"
 description: "A guide on using Sprout to structure and organize your data."
 ---
 
-{{< include /docs/includes/_wip.qmd >}}

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -2,8 +2,6 @@
 title: "Creating and managing data packages"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}
-
 At the core of Sprout is the [data
 package](/docs/design/implementation/outputs.qmd), which is a
 standardized way of structuring and sharing data. This guide will show

--- a/docs/includes/_wip.qmd
+++ b/docs/includes/_wip.qmd
@@ -1,4 +1,0 @@
-::: {.callout-warning appearance="default" icon="true"}
-🚧 This section is still in active development and is subject to changes
-🚧
-:::

--- a/index.qmd
+++ b/index.qmd
@@ -2,4 +2,3 @@
 title: "Welcome to Seedcase Sprout!"
 ---
 
-{{< include /docs/includes/_wip.qmd >}}


### PR DESCRIPTION
## Description

There is a config setting that's fairly new that allows you to put a header in all documents. So rather than use `include` shortcodes for putting the WIP in all documents, this simplifies it so the WIP callout is automatically added to all pages.

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.
