### PR TITLE
fix: :pencil2: broken link to guide index file

### DIFF
--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -28,7 +28,7 @@ Other potential extensions would follow the same or similar pattern.
 This allows other developers to create their own extensions and
 interfaces to Sprout that suit their particular needs.
 
-Our [Guide](/guide/index.qmd) has examples and tutorials on how each
+Our [Guide](../../guide/index.qmd) has examples and tutorials on how each
 split is used.
 
 -   For our CLI, it is placed in the module `sprout/cli/`. Each command

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -28,8 +28,8 @@ Other potential extensions would follow the same or similar pattern.
 This allows other developers to create their own extensions and
 interfaces to Sprout that suit their particular needs.
 
-Our [Guide](../../guide/index.qmd) has examples and tutorials on how each
-split is used.
+Our [Guide](../../guide/index.qmd) has examples and tutorials on how
+each split is used.
 
 -   For our CLI, it is placed in the module `sprout/cli/`. Each command
     imports the relevant functions from `sprout.core`, along with
@@ -41,8 +41,8 @@ split is used.
     Python packages that convert that code into a web app.
 
 -   The web API is in `sprout/api/`. Each endpoint imports the required
-    functions from `sprout.core` with
-    functions from other Python packages that convert that code into a
-    web API. This particular module may not be necessary as many Python
-    packages that create web apps are also able to easily create web
-    APIs from the same or slightly modified code.
+    functions from `sprout.core` with functions from other Python
+    packages that convert that code into a web API. This particular
+    module may not be necessary as many Python packages that create web
+    apps are also able to easily create web APIs from the same or
+    slightly modified code.


### PR DESCRIPTION
## Description

These changes are to fix a broken link to the guide index file.

Closes #

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

Focus on CHANGES.

## Checklist

- [X] Linted and formatted code
- [X] Build passed locally

