### PR TITLE
fix: :bug: sort ids before returning them

### DIFF
--- a/sprout/core/get_ids.py
+++ b/sprout/core/get_ids.py
@@ -16,7 +16,7 @@ def get_ids(path: Path) -> list[int]:
     dirs = list(path.glob("*/"))
     ids = list(map(get_number_from_dir, dirs))
     # Drop any empty items
-    ids = list(filter(None, ids))
+    ids = sorted(filter(None, ids))
 
     return ids
 


### PR DESCRIPTION
## Description

This sorts IDs before returning them. It seems to be the case that the order in which dirs are returned is not determined by Python, which can lead to some inconsistent behaviour. This is causing some tests to fail remotely, but not locally (for me at least). 

Even more interestingly, the tests are run for PRs where neither one of the participating branches even has the commit with the test (🤔). I have no idea why and this does nothing to resolve that.

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

Focus on CHANGES.

## Checklist

- [x] Added or updated tests
- [x] Tests passed locally
- [x] Linted and formatted code
- [x] Build passed locally
- [x] Updated documentation
