### PR TITLE
feat: ✨ add that `path_packages()` creates dir if it doesn't exist

### DIFF
--- a/sprout/core/path_package_functions.py
+++ b/sprout/core/path_package_functions.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from sprout.core.create_dirs import create_dir
 from sprout.core.path_sprout_root import path_sprout_root
 from sprout.core.verify_is_dir import verify_is_dir
 from sprout.core.verify_is_file import verify_is_file
@@ -54,4 +55,5 @@ def path_packages() -> Path:
     Raises:
         NotADirectoryError: If the packages folder doesn't exist.
     """
-    return verify_is_dir(path_sprout_root() / "packages")
+    path = path_sprout_root() / "packages"
+    return create_dir(path) if not path.exists() else verify_is_dir(path)

--- a/tests/core/test_path_package_functions.py
+++ b/tests/core/test_path_package_functions.py
@@ -36,6 +36,7 @@ def test_path_package_functions_return_expected_path(
 ):
     # When, then
     assert function(package_id=1) == tmp_sprout_root / expected_path
+    assert function(package_id=1).is_file() or function(package_id=1).is_dir()
 
 
 @mark.parametrize(
@@ -55,7 +56,12 @@ def test_path_packages_returns_expected_path(tmp_sprout_root):
     assert path_packages() == tmp_sprout_root / "packages"
 
 
-def test_path_packages_raises_error_when_no_packages_exist():
-    # When, then
-    with raises(NotADirectoryError):
-        path_packages()
+def test_path_packages_creates_and_returns_expected_path_when_no_packages_exist(
+    monkeypatch, tmp_path
+):
+    # When
+    monkeypatch.setenv("SPROUT_ROOT", str(tmp_path))
+
+    # Then
+    assert path_packages() == tmp_path / "packages"
+    assert path_packages().is_dir()


### PR DESCRIPTION
## Description

This PR changes the behaviour of `path_packages()` to create the `/packages` directory if it doesn't exist.

Closes #780 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [X] Added or updated tests
- [X] Tests passed locally
- [X] Linted and formatted code
- [X] Build passed locally
