### PR TITLE
feat: ✨ verify data path before extracting ID

### DIFF
--- a/sprout/core/verify_data_path.py
+++ b/sprout/core/verify_data_path.py
@@ -21,9 +21,9 @@ def verify_data_path(properties: dict) -> dict:
     if len(data_path.parts) != 3 or not data_path.parts[1].isdigit():
         error = ResourceError(
             note=(
-                "No resource ID found in the field `path` in resource properties. The `path` field on the "
-                "resource should point to the associated data file. "
-                "Are you sure you set up the resource correctly?"
+                "No resource ID found in the field `path` in resource properties. The "
+                "`path` field on the resource should point to the associated data "
+                "file. Are you sure you set up the resource correctly?"
             )
         )
         raise NotPropertiesError([error], properties)

--- a/sprout/core/verify_data_path.py
+++ b/sprout/core/verify_data_path.py
@@ -6,7 +6,7 @@ from sprout.core.not_properties_error import NotPropertiesError
 
 
 def verify_data_path(properties: dict) -> dict:
-    """Checks if the data path on the resource properties is well formed.
+    """Checks if the data path in the resource properties is well-formed.
 
     Args:
         properties: The resource properties to check.
@@ -21,7 +21,7 @@ def verify_data_path(properties: dict) -> dict:
     if len(data_path.parts) != 3 or not data_path.parts[1].isdigit():
         error = ResourceError(
             note=(
-                "No resource ID found on resource properties. The `path` field on the "
+                "No resource ID found in the field `path` in resource properties. The `path` field on the "
                 "resource should point to the associated data file. "
                 "Are you sure you set up the resource correctly?"
             )

--- a/sprout/core/verify_data_path.py
+++ b/sprout/core/verify_data_path.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from frictionless.errors import ResourceError
+
+from sprout.core.not_properties_error import NotPropertiesError
+
+
+def verify_data_path(properties: dict) -> dict:
+    """Checks if the data path on the resource properties is well formed.
+
+    Args:
+        properties: The resource properties to check.
+
+    Returns:
+        The properties, if the data path is well formed.
+
+    Raises:
+        NotPropertiesError: If the data path is not well formed.
+    """
+    data_path = Path(properties.get("path", ""))
+    if len(data_path.parts) != 3 or not data_path.parts[1].isdigit():
+        error = ResourceError(
+            note=(
+                "No resource ID found on resource properties. The `path` field on the "
+                "resource should point to the associated data file. "
+                "Are you sure you set up the resource correctly?"
+            )
+        )
+        raise NotPropertiesError([error], properties)
+
+    return properties

--- a/sprout/core/verify_resource_properties.py
+++ b/sprout/core/verify_resource_properties.py
@@ -1,8 +1,6 @@
-from pathlib import Path
-
 from frictionless.errors import ResourceError
 
-from sprout.core.not_properties_error import NotPropertiesError
+from sprout.core.verify_data_path import verify_data_path
 from sprout.core.verify_properties_are_complete import verify_properties_are_complete
 from sprout.core.verify_properties_are_well_formed import (
     verify_properties_are_well_formed,
@@ -32,31 +30,5 @@ def verify_resource_properties(properties: dict) -> dict:
     )
     verify_properties_are_well_formed(properties, ResourceError.type)
     verify_data_path(properties)
-
-    return properties
-
-
-def verify_data_path(properties: dict) -> dict:
-    """Checks if the data path on the resource properties is well formed.
-
-    Args:
-        properties: The resource properties to check.
-
-    Returns:
-        The properties, if the data path is well formed.
-
-    Raises:
-        NotPropertiesError: If the data path is not well formed.
-    """
-    data_path = Path(properties["path"])
-    if len(data_path.parts) != 3 or not data_path.parts[1].isdigit():
-        error = ResourceError(
-            note=(
-                "No resource ID found on resource properties. The `path` field on the "
-                "resource should point to the associated data file. "
-                "Are you sure you set up the resource correctly?"
-            )
-        )
-        raise NotPropertiesError([error], properties)
 
     return properties

--- a/sprout/core/write_resource_properties.py
+++ b/sprout/core/write_resource_properties.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from sprout.core.read_json import read_json
+from sprout.core.verify_data_path import verify_data_path
 from sprout.core.verify_is_file import verify_is_file
 from sprout.core.verify_package_properties import verify_package_properties
 from sprout.core.verify_resource_properties import verify_resource_properties
@@ -67,5 +68,10 @@ def get_resource_id_from_properties(resource_properties: dict) -> int:
 
     Returns:
         The ID of the resource.
+
+    Raises:
+        NotPropertiesError: If the resource properties have a malformed or missing
+            data path.
     """
+    verify_data_path(resource_properties)
     return int(Path(resource_properties["path"]).parts[1])

--- a/tests/core/test_verify_data_path.py
+++ b/tests/core/test_verify_data_path.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from pytest import fixture, mark, raises
+
+from sprout.core.not_properties_error import NotPropertiesError
+from sprout.core.properties import ResourceProperties
+from sprout.core.verify_data_path import verify_data_path
+
+
+@fixture
+def resource_properties() -> dict:
+    return ResourceProperties(
+        name="my-resource",
+        path=str(Path("resources", "1", "data.parquet")),
+        title="My Resource",
+        description="This is my resource.",
+    ).asdict
+
+
+def test_accepts_well_formed_path(resource_properties):
+    """Should accept a set of properties with a well-formed data path."""
+    assert verify_data_path(resource_properties) == resource_properties
+
+
+def test_rejects_properties_with_no_path(resource_properties):
+    """Given a set of properties without a data path, should throw
+    NotPropertiesError."""
+    del resource_properties["path"]
+
+    with raises(
+        NotPropertiesError,
+        match="No resource ID found on resource properties",
+    ):
+        verify_data_path(resource_properties)
+
+
+@mark.parametrize(
+    "data_path",
+    [
+        Path("resources", "x", "data.parquet"),
+        Path("1", "data.parquet"),
+        Path("resources", "1", "data.parquet", "1"),
+    ],
+)
+def test_rejects_malformed_path(resource_properties, data_path):
+    """Given a set of properties with a malformed data path, should throw
+    NotPropertiesError."""
+    resource_properties["path"] = str(data_path)
+
+    with raises(
+        NotPropertiesError,
+        match="No resource ID found on resource properties",
+    ):
+        verify_data_path(resource_properties)

--- a/tests/core/test_verify_data_path.py
+++ b/tests/core/test_verify_data_path.py
@@ -29,7 +29,7 @@ def test_rejects_properties_with_no_path(resource_properties):
 
     with raises(
         NotPropertiesError,
-        match="No resource ID found on resource properties",
+        match="No resource ID found",
     ):
         verify_data_path(resource_properties)
 
@@ -49,6 +49,6 @@ def test_rejects_malformed_path(resource_properties, data_path):
 
     with raises(
         NotPropertiesError,
-        match="No resource ID found on resource properties",
+        match="No resource ID found",
     ):
         verify_data_path(resource_properties)

--- a/tests/core/test_verify_resource_properties.py
+++ b/tests/core/test_verify_resource_properties.py
@@ -6,7 +6,6 @@ from sprout.core.not_properties_error import NotPropertiesError
 from sprout.core.properties import ResourceProperties, TableSchemaProperties
 from sprout.core.verify_resource_properties import (
     REQUIRED_RESOURCE_PROPERTIES,
-    verify_data_path,
     verify_resource_properties,
 )
 
@@ -75,7 +74,6 @@ def test_rejects_empty_value_for_required_fields(
         verify_resource_properties(resource_properties)
 
 
-@mark.parametrize("verify", [verify_data_path, verify_resource_properties])
 @mark.parametrize(
     "data_path",
     [
@@ -84,7 +82,7 @@ def test_rejects_empty_value_for_required_fields(
         Path("resources", "1", "data.parquet", "1"),
     ],
 )
-def test_rejects_malformed_path(resource_properties, data_path, verify):
+def test_rejects_malformed_path(resource_properties, data_path):
     """Given a set of properties with a malformed data path, should throw
     NotPropertiesError."""
     resource_properties["path"] = str(data_path)
@@ -93,4 +91,4 @@ def test_rejects_malformed_path(resource_properties, data_path, verify):
         NotPropertiesError,
         match="No resource ID found on resource properties",
     ):
-        verify(resource_properties)
+        verify_resource_properties(resource_properties)

--- a/tests/core/test_verify_resource_properties.py
+++ b/tests/core/test_verify_resource_properties.py
@@ -89,6 +89,6 @@ def test_rejects_malformed_path(resource_properties, data_path):
 
     with raises(
         NotPropertiesError,
-        match="No resource ID found on resource properties",
+        match="No resource ID found",
     ):
         verify_resource_properties(resource_properties)

--- a/tests/core/test_write_resource_properties.py
+++ b/tests/core/test_write_resource_properties.py
@@ -136,15 +136,40 @@ def test_throws_error_if_resource_properties_are_incorrect(package_properties_pa
         write_resource_properties(package_properties_path, {})
 
 
-def test_throws_error_if_data_path_malformed(
+def test_throws_error_if_data_path_malformed_on_new_resource(
     package_properties_path, resource_properties_1
 ):
-    """Should throw NotPropertiesError if the data path of the resource is
+    """Should throw NotPropertiesError if the data path of the new resource is
     malformed."""
     resource_properties_1.path = str(Path("no", "id"))
 
     with raises(NotPropertiesError):
         write_resource_properties(package_properties_path, resource_properties_1.asdict)
+
+
+def test_throws_error_if_data_path_malformed_on_existing_resource(
+    tmp_path, resource_properties_1, resource_properties_2
+):
+    """Should throw NotPropertiesError if the data path of an existing resource is
+    malformed."""
+    # given
+    resource_properties_1.path = str(Path("no", "id"))
+    package_properties = PackageProperties(
+        name="my-package",
+        id="123-abc-123",
+        title="My Package",
+        description="This is my package.",
+        version="2.0.0",
+        created="2024-05-14T05:00:01+00:00",
+        resources=[resource_properties_1],
+    )
+    package_properties_path = write_json(
+        package_properties.asdict, tmp_path / "datapackage.json"
+    )
+
+    # when + then
+    with raises(NotPropertiesError):
+        write_resource_properties(package_properties_path, resource_properties_2.asdict)
 
 
 def test_throws_error_if_package_properties_are_incorrect(


### PR DESCRIPTION
## Description

This PR makes sure that every time we extract the ID from the data path of a resource, we verify that it is well formed ([discussion](https://github.com/seedcase-project/seedcase-sprout/pull/784#discussion_r1801271054)). 

Related to #784

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Tests passed locally
- [x] Linted and formatted code
- [x] Build passed locally
- [x] Updated documentation
