### PR TITLE
feat: :sparkles: add `check_raw_data` function

### DIFF
--- a/sprout/core/check_raw_data.py
+++ b/sprout/core/check_raw_data.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from frictionless import Resource
+
+from sprout.core.get_extension import get_extension
+from sprout.core.get_report_errors import get_report_errors
+from sprout.core.mismatched_raw_data_error import MismatchedRawDataError
+from sprout.core.path_sprout_root import path_sprout_root
+
+
+def check_raw_data(resource_properties: dict, data_path: Path) -> Path:
+    """Checks a raw data file against a set of resource properties.
+
+    Args:
+        resource_properties: The resource properties to check against.
+        data_path: The path to the raw data file.
+
+    Returns:
+        The path to the raw data file, if the data match the properties.
+
+    Raises:
+        MismatchedRawDataError: If the data do not match the properties.
+    """
+    resource = Resource.from_descriptor(resource_properties)
+    resource.format = get_extension(data_path)
+    resource.scheme = "file"
+    resource.basepath = str(path_sprout_root())
+    resource.path = str(data_path.relative_to(path_sprout_root()))
+
+    report = resource.validate()
+    errors = get_report_errors(report)
+    if errors:
+        raise MismatchedRawDataError(errors, data_path)
+
+    return data_path

--- a/sprout/core/get_extension.py
+++ b/sprout/core/get_extension.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from sprout.core.verify_is_file import verify_is_file
+
+
+def get_extension(path: Path) -> str:
+    """Returns the extension of the file `path` points to without a leading `.`.
+
+    Args:
+        path: The path to the file.
+
+    Returns:
+        The extension of the file.
+
+    Raises:
+        FileNotFoundError: If `path` does not point to a file.
+    """
+    verify_is_file(path)
+    return path.suffix[1:]

--- a/sprout/core/get_report_errors.py
+++ b/sprout/core/get_report_errors.py
@@ -1,0 +1,17 @@
+from frictionless import Error, Report
+
+
+def get_report_errors(report: Report) -> list[Error]:
+    """Returns all errors in a Frictionless report.
+
+    Args:
+        report: The report to get the errors from.
+
+    Returns:
+        The errors in the report.
+    """
+    return [
+        error
+        for error in report.errors
+        + [error for task in report.tasks for error in task.errors]
+    ]

--- a/sprout/core/mismatched_raw_data_error.py
+++ b/sprout/core/mismatched_raw_data_error.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from frictionless import Error
+
+
+class MismatchedRawDataError(Exception):
+    """Raised when a raw data file does not conform to the resource properties."""
+
+    def __init__(self, errors: list[Error], data_path: Path, *args, **kwargs):
+        """Initialises MismatchedRawDataError.
+
+        Args:
+            errors: List of Frictionless errors.
+            data_path: Path to the raw data file.
+            *args: Non-keyword arguments.
+            **kwargs: Keyword arguments.
+        """
+        errors = [
+            f"{error.title}: {error.description} {error.message}" for error in errors
+        ]
+        message = (
+            f"The raw data file at `{data_path}` does not conform to the corresponding "
+            "resource properties."
+            f"\nThe following errors were found:\n{'\n'.join(errors)}"
+        )
+        super().__init__(message, *args, **kwargs)

--- a/sprout/core/verify_properties_are_well_formed.py
+++ b/sprout/core/verify_properties_are_well_formed.py
@@ -1,5 +1,6 @@
 from frictionless import validate
 
+from sprout.core.get_report_errors import get_report_errors
 from sprout.core.not_properties_error import NotPropertiesError
 
 
@@ -26,12 +27,7 @@ def verify_properties_are_well_formed(properties: dict, error_type: str) -> dict
     }
     report = validate(non_empty_properties)
 
-    errors = [
-        error
-        for error in report.errors
-        + [error for task in report.tasks for error in task.errors]
-        if error.type == error_type
-    ]
+    errors = [error for error in get_report_errors(report) if error.type == error_type]
     if errors:
         raise NotPropertiesError(errors, properties)
 

--- a/tests/core/test_check_raw_data.py
+++ b/tests/core/test_check_raw_data.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+from pytest import fixture, mark, raises
+
+from sprout.core.check_raw_data import check_raw_data
+from sprout.core.mismatched_raw_data_error import MismatchedRawDataError
+from sprout.core.properties import ResourceProperties, TableSchemaProperties
+from sprout.core.write_file import write_file
+
+
+@fixture
+def sprout_root(tmp_path, monkeypatch) -> Path:
+    ROOT = tmp_path / "root"
+    monkeypatch.setenv("SPROUT_ROOT", str(ROOT))
+    return ROOT
+
+
+@fixture
+def path_to_data(sprout_root) -> Path:
+    sprout_root.mkdir()
+    file_path = sprout_root / "data.csv"
+    data = "id,name,dob\n1,Alice,2000-09-22\n2,Bob,1996-11-12\n"
+    return write_file(data, file_path)
+
+
+@fixture
+def resource_properties() -> dict:
+    return ResourceProperties(
+        name="resource-1",
+        title="My First Resource",
+        description="This is my first resource.",
+        schema=TableSchemaProperties(),
+    ).asdict
+
+
+def test_accepts_matching_data(path_to_data, resource_properties):
+    """Should accept data matching the table schema."""
+    resource_properties["schema"]["fields"] += [
+        {"name": "id", "type": "integer"},
+        {"name": "name", "type": "string"},
+        {"name": "dob", "type": "date"},
+    ]
+
+    assert check_raw_data(resource_properties, path_to_data) == path_to_data
+
+
+def test_rejects_empty_data(path_to_data, resource_properties):
+    """Should reject an empty data file."""
+    write_file("", path_to_data)
+
+    with raises(MismatchedRawDataError, match="the source is empty"):
+        check_raw_data(resource_properties, path_to_data)
+
+
+def test_rejects_uneven_data(path_to_data, resource_properties):
+    """Should reject a data file with rows of different lengths."""
+    path_to_data.write_text(
+        path_to_data.read_text() + "3,Carl,1996-11-12,and,four,more,cells\n"
+    )
+    resource_properties["schema"]["fields"] += [
+        {"name": "id", "type": "integer"},
+        {"name": "name", "type": "string"},
+        {"name": "dob", "type": "date"},
+    ]
+
+    with raises(MismatchedRawDataError) as error:
+        check_raw_data(resource_properties, path_to_data)
+
+    message = str(error.value)
+    assert message.count("Extra Cell") == 4
+
+
+@mark.parametrize(
+    "fields, error_codes",
+    [
+        ([], ["Extra Label", "Blank Row"]),
+        ([{"name": "id", "type": "integer"}], ["Extra Label", "Extra Cell"]),
+        (
+            [
+                {"name": "id", "type": "integer"},
+                {"name": "name", "type": "integer"},
+                {"name": "dob", "type": "date"},
+            ],
+            ["Type Error"],
+        ),
+    ],
+)
+def test_rejects_mismatched_data(
+    path_to_data, resource_properties, fields, error_codes
+):
+    """Should reject a data file that does not match the table schema."""
+    resource_properties["schema"]["fields"] += fields
+
+    with raises(MismatchedRawDataError) as error:
+        check_raw_data(resource_properties, path_to_data)
+
+    message = str(error.value)
+    for code in error_codes:
+        assert code in message
+
+
+def test_accepts_matching_data_with_constraints(path_to_data, resource_properties):
+    """Should accept a data file that conforms to schema constraints."""
+    resource_properties["schema"]["fields"] += [
+        {"name": "id", "type": "integer"},
+        {"name": "name", "type": "string", "constraints": {"maxLength": 10}},
+        {"name": "dob", "type": "date"},
+    ]
+
+    assert check_raw_data(resource_properties, path_to_data) == path_to_data
+
+
+def test_rejects_data_violating_constraints(path_to_data, resource_properties):
+    """Should reject a data file that violates schema constraints."""
+    resource_properties["schema"]["fields"] += [
+        {"name": "id", "type": "integer"},
+        {"name": "name", "type": "string", "constraints": {"maxLength": 4}},
+        {"name": "dob", "type": "date"},
+    ]
+
+    with raises(MismatchedRawDataError, match="Constraint Error"):
+        check_raw_data(resource_properties, path_to_data)

--- a/tests/core/test_get_extension.py
+++ b/tests/core/test_get_extension.py
@@ -1,0 +1,24 @@
+from pytest import mark, raises
+
+from sprout.core.get_extension import get_extension
+
+
+@mark.parametrize("filename, extension", [("test.csv", "csv"), ("test.tar.gz", "gz")])
+def test_gets_extension_correctly(tmp_path, filename, extension):
+    """Should return the file extension correctly."""
+    path = tmp_path / filename
+    path.touch()
+
+    assert get_extension(path) == extension
+
+
+def test_rejects_path_if_not_file(tmp_path):
+    """Should throw FileNotFoundError if the path does not point to a file."""
+    with raises(FileNotFoundError):
+        get_extension(tmp_path)
+
+
+def test_rejects_path_if_file_does_not_exist(tmp_path):
+    """Should throw FileNotFoundError if the path does not exist."""
+    with raises(FileNotFoundError):
+        get_extension(tmp_path / "nonexistent.txt")

--- a/tests/core/test_get_report_errors.py
+++ b/tests/core/test_get_report_errors.py
@@ -1,0 +1,31 @@
+from frictionless import Error, Report, ReportTask
+
+from sprout.core.get_report_errors import get_report_errors
+
+
+def test_gets_errors_correctly():
+    """Extracts errors from both the report itself and its tasks."""
+    expected_errors = [Error(note=f"error {n}") for n in range(5)]
+    report = Report(
+        valid=False,
+        errors=expected_errors[:2],
+        tasks=[
+            create_report_task([expected_errors[2]]),
+            create_report_task(expected_errors[3:]),
+        ],
+        stats={"tasks": 2, "errors": len(expected_errors)},
+    )
+
+    assert get_report_errors(report) == expected_errors
+
+
+def create_report_task(errors: list[Error]) -> ReportTask:
+    return ReportTask(
+        errors=errors,
+        name="test",
+        valid=False,
+        place="test",
+        type="test",
+        labels=[],
+        stats={"errors": len(errors)},
+    )


### PR DESCRIPTION
## Description

This PR adds a `check_raw_data` function. This is a combination of `verify_raw_data` and `validate_raw_data` because `frictionless` has one function for these. We can still split the function into two based on the error codes, but I wanted to put it up for discussion before making it more complicated.

Feel free to suggest better names for `check_raw_data` and the error it throws (if we're keeping them).

Note that I added `resource_properties: dict` as an argument instead of reading it from file inside `check_raw_data`. I'll put up another PR for loading the resource properties from `datapackage.json`, because this seemed like a separate task and raised its own questions.

Closes #800, #801

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Tests passed locally
- [x] Linted and formatted code
- [x] Build passed locally
- [x] Updated documentation
