### PR TITLE
fix: 🩹  update `verify_properties_are_well_formed()` based on changes to the `Properties` classes

### DIFF
--- a/sprout/core/verify_properties_are_well_formed.py
+++ b/sprout/core/verify_properties_are_well_formed.py
@@ -24,7 +24,7 @@ def verify_properties_are_well_formed(properties: dict, error_type: str) -> dict
     non_empty_properties = {
         key: value for key, value in properties.items() if value != ""
     }
-    report = validate(non_empty_properties)
+    report = validate(non_empty_properties, type=error_type.replace("-error", ""))
 
     errors = [
         error

--- a/sprout/core/verify_properties_are_well_formed.py
+++ b/sprout/core/verify_properties_are_well_formed.py
@@ -1,4 +1,5 @@
 from frictionless import validate
+from frictionless.errors import Error
 
 from sprout.core.not_properties_error import NotPropertiesError
 
@@ -31,6 +32,10 @@ def verify_properties_are_well_formed(properties: dict, error_type: str) -> dict
         for error in report.errors
         if "required" not in error.message and error.type == error_type
     ]
+
+    if properties == {}:
+        errors = [Error(note="Empty properties provided")]
+
     if errors:
         raise NotPropertiesError(errors, properties)
 

--- a/sprout/core/verify_properties_are_well_formed.py
+++ b/sprout/core/verify_properties_are_well_formed.py
@@ -29,8 +29,7 @@ def verify_properties_are_well_formed(properties: dict, error_type: str) -> dict
     errors = [
         error
         for error in report.errors
-        + [error for task in report.tasks for error in task.errors]
-        if error.type == error_type
+        if "required" not in error.message and error.type == error_type
     ]
     if errors:
         raise NotPropertiesError(errors, properties)

--- a/tests/core/test_verify_properties_are_well_formed.py
+++ b/tests/core/test_verify_properties_are_well_formed.py
@@ -60,7 +60,7 @@ def test_accepts_default_values(properties_cls, error_type):
         ("resource_properties", resource_error),
     ],
 )
-def test_accepts_custom_values(properties, error_type, request):
+def test_accepts_well_formed_properties_object(properties, error_type, request):
     """Should accept a well-formed properties object."""
     properties = request.getfixturevalue(properties)
 

--- a/tests/core/test_verify_properties_are_well_formed.py
+++ b/tests/core/test_verify_properties_are_well_formed.py
@@ -103,3 +103,9 @@ def test_filters_for_resource_errors(resource_properties):
         verify_properties_are_well_formed(resource_properties, resource_error)
         == resource_properties
     )
+
+
+def test_throws_error_if_properties_are_empty():
+    """Should throw NotPropertiesError if the properties are empty."""
+    with raises(NotPropertiesError):
+        verify_properties_are_well_formed({}, package_error)

--- a/tests/core/test_verify_properties_are_well_formed.py
+++ b/tests/core/test_verify_properties_are_well_formed.py
@@ -86,7 +86,7 @@ def test_rejects_properties_not_conforming_to_spec(properties, error_type, reque
 def test_filters_for_package_errors(package_properties):
     """Should throw only if PackageErrors are detected."""
     bad_resource = ResourceProperties(name="a bad name with spaces").compact_dict
-    package_properties["resources"].append(bad_resource)
+    package_properties["resources"] = [bad_resource]
 
     assert (
         verify_properties_are_well_formed(package_properties, package_error)


### PR DESCRIPTION
## Description

NB this is a stacked PR merging to #808 

This PR changes the behaviour of `verify_properties_are_wellformed()` based on the changes to the `Properties` classes in #808 

This work was done in collaboration with @martonvago 🌷 It's not pretty, but it gets the work done for now.
During this, we talked about #830 and how we think not using `frictionless-py` could simplify the work here as well, since the `validate()`function keeps surprising us by not working as we expect it to.

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [X] Added or updated tests
- [X] Tests passed locally
- [X] Linted and formatted code
