### PR TITLE
fix: 🩹 update `edit_package_properties()` based on the changes to the `Properties` classes

### DIFF
--- a/sprout/core/edit_package_properties.py
+++ b/sprout/core/edit_package_properties.py
@@ -54,4 +54,5 @@ def edit_package_properties(path: Path, properties: dict) -> dict:
     verify_properties_are_well_formed(current_properties, PackageError.type)
 
     current_properties.update(properties)
-    return current_properties
+
+    return verify_package_properties(current_properties)

--- a/sprout/core/edit_package_properties.py
+++ b/sprout/core/edit_package_properties.py
@@ -48,7 +48,7 @@ def edit_package_properties(path: Path, properties: dict) -> dict:
         JSONDecodeError: If the `datapackage.json` file couldn't be read.
     """
     verify_is_file(path)
-    verify_package_properties(properties)
+    verify_properties_are_well_formed(properties, PackageError.type)
 
     current_properties = read_json(path)
     verify_properties_are_well_formed(current_properties, PackageError.type)

--- a/tests/core/test_edit_package_properties.py
+++ b/tests/core/test_edit_package_properties.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from pytest import fixture, raises
 
+from sprout.core.create_package_structure import create_package_structure
 from sprout.core.edit_package_properties import edit_package_properties
 from sprout.core.not_properties_error import NotPropertiesError
 from sprout.core.properties import PackageProperties
@@ -23,8 +24,21 @@ def properties():
 
 @fixture
 def properties_path(tmp_path) -> Path:
-    package_properties = PackageProperties(version="1.0.0")
-    return write_json(package_properties.asdict, tmp_path / "datapackage.json")
+    properties_path = create_package_structure(tmp_path)[0]
+    # Write a correct properties file to be edited
+    write_json(
+        PackageProperties(
+            name="my-package",
+            id="123-abc-123",
+            title="My Package",
+            description="This is my package.",
+            version="1.0.0",
+            created="2024-05-14T05:00:01+00:00",
+            resources=[],
+        ).compact_dict,
+        properties_path,
+    )
+    return properties_path
 
 
 def test_edits_package_properties(properties_path, properties):

--- a/tests/core/test_edit_package_properties.py
+++ b/tests/core/test_edit_package_properties.py
@@ -92,7 +92,7 @@ def test_adds_custom_fields(
     new_properties = {"custom-field": "custom-value"}
 
     # When, Then
-    edit_package_properties(
+    assert edit_package_properties(
         properties_path, new_properties
     ) == current_properties | new_properties
 

--- a/tests/core/test_edit_package_properties.py
+++ b/tests/core/test_edit_package_properties.py
@@ -83,7 +83,7 @@ def test_throws_error_if_current_package_properties_are_malformed(tmp_path, prop
         edit_package_properties(path, properties)
 
 
-def test_throws_error_if_new_package_properties_are_incorrect(properties_path):
-    """Should throw NotPropertiesError if the new package properties are incorrect."""
+def test_throws_error_if_new_properties_are_empty(properties_path):
+    """Should throw NotPropertiesError if the new properties are empty."""
     with raises(NotPropertiesError):
         edit_package_properties(properties_path, {})

--- a/tests/core/test_edit_package_properties.py
+++ b/tests/core/test_edit_package_properties.py
@@ -7,6 +7,7 @@ from sprout.core.create_package_structure import create_package_structure
 from sprout.core.edit_package_properties import edit_package_properties
 from sprout.core.not_properties_error import NotPropertiesError
 from sprout.core.properties import PackageProperties
+from sprout.core.read_json import read_json
 from sprout.core.write_json import write_json
 
 
@@ -41,9 +42,14 @@ def properties_path(tmp_path) -> Path:
     return properties_path
 
 
-def test_edits_package_properties(properties_path, properties):
-    """Should update package properties."""
-    assert edit_package_properties(properties_path, properties) == properties
+def test_edits_only_changed_package_properties(properties_path, properties):
+    """Should only edit package properties and leave unchanged values as is."""
+    # Given
+    current_properties = read_json(properties_path)
+
+    # When, Then
+    expected_properties = current_properties | properties
+    assert edit_package_properties(properties_path, properties) == expected_properties
 
 
 def test_throws_error_if_path_points_to_dir(tmp_path):

--- a/tests/core/test_edit_package_properties.py
+++ b/tests/core/test_edit_package_properties.py
@@ -83,6 +83,20 @@ def test_throws_error_if_current_package_properties_are_malformed(tmp_path, prop
         edit_package_properties(path, properties)
 
 
+def test_adds_custom_fields(
+    properties_path,
+):
+    """Should add custom fields to properties."""
+    # Given
+    current_properties = read_json(properties_path)
+    new_properties = {"custom-field": "custom-value"}
+
+    # When, Then
+    edit_package_properties(
+        properties_path, new_properties
+    ) == current_properties | new_properties
+
+
 def test_throws_error_if_new_properties_are_empty(properties_path):
     """Should throw NotPropertiesError if the new properties are empty."""
     with raises(NotPropertiesError):


### PR DESCRIPTION
## Description

NB this is a stacked PR merging to #808 

This PR changes the behaviour of `edit_package_properties()` based on the changes to the `Properties` classes in #808 

This work was done in collaboration with @martonvago 🌷

<!-- Select quick/in-depth as necessary -->
## Checklist

- [X] Added or updated tests
- [X] Tests passed locally
- [X] Linted and formatted code
- [X] Build passed locally