### PR TITLE
chore: :wrench: update link to glossary

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,7 +6,7 @@ project:
     - "index.qmd"
 
 glossary:
-  path: _extensions/debruine/glossary/glossary.yml
+  path: _extensions/seedcase-project/seedcase-theme/glossary.yml
   popup: none
   show: true
 


### PR DESCRIPTION
## Description

The path to the glossary was wrong, so fixed it.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

