### PR TITLE
feat: ✨ add `create_raw_file_name()`

### DIFF
--- a/sprout/core/create_raw_file_name.py
+++ b/sprout/core/create_raw_file_name.py
@@ -8,7 +8,7 @@ def create_raw_file_name(path: Path) -> str:
     """Generates a unique filename for a raw file.
 
     Args:
-        path: The path to the raw file.
+        path: The path to the raw file to extract the original extension from.
 
     Returns:
         The created raw file name in the format {timestamp}-{uuid}{ext}.gz

--- a/sprout/core/create_raw_file_name.py
+++ b/sprout/core/create_raw_file_name.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from uuid import uuid4
+
+from sprout.core.get_iso_timestamp import get_compact_iso_timestamp
+
+
+def create_raw_file_name(path: Path) -> str:
+    """Generates a unique filename for a raw file.
+
+    Args:
+        path: The path to the raw file.
+
+    Returns:
+        The created raw file name in the format {timestamp}-{uuid}{ext}.gz
+    """
+    return f"{get_compact_iso_timestamp()}-{uuid4()}{path.suffix}.gz"

--- a/sprout/core/get_iso_timestamp.py
+++ b/sprout/core/get_iso_timestamp.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from re import sub
 
 
 def get_iso_timestamp() -> str:
@@ -17,4 +16,4 @@ def get_compact_iso_timestamp() -> str:
     Returns:
         The timestamp as a string. E.g. `20240514-05000100`.
     """
-    return sub(r"\W", "", get_iso_timestamp()).replace("T", "-")
+    return datetime.now().strftime("%Y-%m-%dT%H%M%SZ")

--- a/sprout/core/get_iso_timestamp.py
+++ b/sprout/core/get_iso_timestamp.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 
 def get_iso_timestamp() -> str:
-    """Generates a timestamp compliant with the Data Package spec.
+    """Generates an ISO timestamp compliant with the Data Package spec.
 
     Returns:
         The timestamp as a string. E.g. `2024-05-14T05:00:01+00:00`.
@@ -11,9 +11,9 @@ def get_iso_timestamp() -> str:
 
 
 def get_compact_iso_timestamp() -> str:
-    """Generates a compact timestamp.
+    """Generates a compact ISO timestamp.
 
     Returns:
-        The timestamp as a string. E.g. `20240514-05000100`.
+        The timestamp as a string. E.g. `2024-05-14T050000Z`.
     """
     return datetime.now().strftime("%Y-%m-%dT%H%M%SZ")

--- a/sprout/core/get_iso_timestamp.py
+++ b/sprout/core/get_iso_timestamp.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from re import sub
 
 
 def get_iso_timestamp() -> str:
@@ -8,3 +9,12 @@ def get_iso_timestamp() -> str:
         The timestamp as a string. E.g. `2024-05-14T05:00:01+00:00`.
     """
     return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def get_compact_iso_timestamp() -> str:
+    """Generates a compact timestamp.
+
+    Returns:
+        The timestamp as a string. E.g. `20240514-05000100`.
+    """
+    return sub(r"\W", "", get_iso_timestamp()).replace("T", "-")

--- a/tests/core/test_create_raw_file_name.py
+++ b/tests/core/test_create_raw_file_name.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+from uuid import UUID
+
+import time_machine
+
+from sprout.core.create_raw_file_name import create_raw_file_name
+
+
+@patch("sprout.core.create_raw_file_name.uuid4", return_value=UUID(int=1))
+@time_machine.travel(datetime(2024, 5, 14, 5, 0, 1), tick=False)
+def test_returns_raw_file_name(mock_uuid, tmp_path):
+    path = create_raw_file_name(Path(tmp_path) / "test.csv")
+
+    assert path == f"20240514-0500010000-{mock_uuid()}.csv.gz"

--- a/tests/core/test_create_raw_file_name.py
+++ b/tests/core/test_create_raw_file_name.py
@@ -10,7 +10,7 @@ from sprout.core.create_raw_file_name import create_raw_file_name
 
 @patch("sprout.core.create_raw_file_name.uuid4", return_value=UUID(int=1))
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1), tick=False)
-def test_returns_raw_file_name(mock_uuid, tmp_path):
+def test_returns_expected_raw_file_name(mock_uuid, tmp_path):
     path = create_raw_file_name(Path(tmp_path) / "test.csv")
 
     assert path == f"20240514-0500010000-{mock_uuid()}.csv.gz"

--- a/tests/core/test_create_raw_file_name.py
+++ b/tests/core/test_create_raw_file_name.py
@@ -13,4 +13,4 @@ from sprout.core.create_raw_file_name import create_raw_file_name
 def test_returns_expected_raw_file_name(mock_uuid, tmp_path):
     path = create_raw_file_name(Path(tmp_path) / "test.csv")
 
-    assert path == f"20240514-0500010000-{mock_uuid()}.csv.gz"
+    assert path == f"2024-05-14T050001Z-{mock_uuid()}.csv.gz"

--- a/tests/core/test_get_iso_timestamp.py
+++ b/tests/core/test_get_iso_timestamp.py
@@ -10,6 +10,7 @@ from sprout.core.get_iso_timestamp import get_compact_iso_timestamp, get_iso_tim
 def test_formats_timestamp_in_utc_correctly():
     """Should return a correctly formatted timestamp in the default timezone."""
     assert get_iso_timestamp() == "2024-05-14T05:00:01+00:00"
+    assert isinstance(datetime.fromisoformat(get_iso_timestamp()), datetime)
 
 
 @time_machine.travel(
@@ -18,9 +19,11 @@ def test_formats_timestamp_in_utc_correctly():
 def test_formats_timestamp_in_other_timezone_correctly():
     """Should return a correctly formatted timestamp in a specific timezone."""
     assert get_iso_timestamp() == "2024-05-14T05:00:01+02:00"
+    assert isinstance(datetime.fromisoformat(get_iso_timestamp()), datetime)
 
 
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1), tick=False)
 def test_removes_nonnumeric_characters_correctly():
     """Should return an iso compatible timestamp with only numeric characters."""
     assert get_compact_iso_timestamp() == "2024-05-14T050001Z"
+    assert isinstance(datetime.fromisoformat(get_compact_iso_timestamp()), datetime)

--- a/tests/core/test_get_iso_timestamp.py
+++ b/tests/core/test_get_iso_timestamp.py
@@ -22,5 +22,5 @@ def test_formats_timestamp_in_other_timezone_correctly():
 
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1), tick=False)
 def test_removes_nonnumeric_characters_correctly():
-    """Should return a timestamp with only numeric characters."""
-    assert get_compact_iso_timestamp() == "20240514-0500010000"
+    """Should return an iso compatible timestamp with only numeric characters."""
+    assert get_compact_iso_timestamp() == "2024-05-14T050001Z"

--- a/tests/core/test_get_iso_timestamp.py
+++ b/tests/core/test_get_iso_timestamp.py
@@ -3,7 +3,7 @@ from zoneinfo import ZoneInfo
 
 import time_machine
 
-from sprout.core.get_iso_timestamp import get_iso_timestamp
+from sprout.core.get_iso_timestamp import get_compact_iso_timestamp, get_iso_timestamp
 
 
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1), tick=False)
@@ -18,3 +18,9 @@ def test_formats_timestamp_in_utc_correctly():
 def test_formats_timestamp_in_other_timezone_correctly():
     """Should return a correctly formatted timestamp in a specific timezone."""
     assert get_iso_timestamp() == "2024-05-14T05:00:01+02:00"
+
+
+@time_machine.travel(datetime(2024, 5, 14, 5, 0, 1), tick=False)
+def test_removes_nonnumeric_characters_correctly():
+    """Should return a timestamp with only numeric characters."""
+    assert get_compact_iso_timestamp() == "20240514-0500010000"


### PR DESCRIPTION
## Description 

This PR adds the function `create_raw_file_name()` with a test. 
For this, I also added a helper function `get_compact_iso_timestamp()` that generates a compact version of the iso timestamp from `get_iso_timestamp(), by removing characters as ":", "T", and "-". It does, however, add a "-" between the data and time for readability.

Closes #802 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [X] Added or updated tests
- [X] Tests passed locally
- [X] Linted and formatted code
