### PR TITLE
docs: :memo: describe split between `lib` and `core`

### DIFF
--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -59,10 +59,3 @@ each split is used.
     imports the required functions from `seedcase_sprout.core`, with
     functions from other Python packages that convert that code into a
     web app.
-
--   The web API is in `seedcase_sprout/api/`. Each endpoint imports the
-    required functions from `seedcase_sprout.core` with functions from
-    other Python packages that convert that code into a web API. This
-    particular module may not be necessary as many Python packages that
-    create web apps are also able to easily create web APIs from the
-    same or slightly modified code.

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -14,7 +14,7 @@ In order to achieve our aims, the main functionality is designed and
 implemented as a Python package and can be used as a Python package.
 This code is stored in the Python module (folder location)
 `seedcase_sprout/core/` and is accessible via the Python code
-`import seedcase_sprout.core` statement. Only external-facing functions
+`import seedcase_sprout.core as sp` statement. Only external-facing functions
 would be exposed to the user and to other programs.
 
 The `core` functions and classes aim to have as few external assumptions
@@ -40,9 +40,9 @@ interfaces to Sprout that suit their particular needs.
 Our [Guide](/docs/guide/index.qmd) has examples and tutorials on how
 each split is used.
 
--   A higher-level, opinionated Python implementation of `core`, named
+-   A higher-level, opinionated Python abstraction of `core`, named
     `lib` and stored in `seedcase_sprout/lib/`. This module abstracts
-    away and simplified many of the steps and functions available in
+    away and simplifies many of the steps and functions available in
     `core`, with the consequence of being less flexible and less
     customizable. This module is intended for users who want to use
     Sprout without having to worry about the finer details of the exact

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -13,36 +13,56 @@ the context of Sprout.
 In order to achieve our aims, the main functionality is designed and
 implemented as a Python package and can be used as a Python package.
 This code is stored in the Python module (folder location)
-`sprout/core/` and is accessible via the Python code
-`import sprout.core` statement. Only external-facing functions would be
-exposed to the user and to other programs.
+`seedcase_sprout/core/` and is accessible via the Python code
+`import seedcase_sprout.core` statement. Only external-facing functions
+would be exposed to the user and to other programs.
+
+The `core` functions and classes aim to have as few external assumptions
+and dependencies as possible. For instance, input and output don't
+depend on the state of any other function. This way, we can have a
+highly flexible, modular, and easily testable `core` that other
+developers (and potentially users) can easily configure and customize to
+their own needs. This modular and flexible "lower level" design allows
+us to create a variety of interfaces and extensions to Sprout.
 
 Any extensions would then only need to incorporate and depend on the
-`sprout.core` package to get Sprout's functionality. Each extension
-would be its own module within Sprout, with modules named like
-`sprout/extension_name/`, for instance, `sprout/cli/`. That way, within
-the extension's module, the logic that we implement is only specific to
-creating the CLI and not to the actual functionality of Sprout.
+`seedcase_sprout.core` package to get Sprout's functionality. Each
+extension would be its own module within Sprout, with modules named like
+`seedcase_sprout/extension_name/`, for instance, `seedcase_sprout/cli/`.
+That way, within the extension's module, the logic that we implement is
+only specific to creating the CLI and not to the actual functionality of
+Sprout.
 
 Other potential extensions would follow the same or similar pattern.
 This allows other developers to create their own extensions and
 interfaces to Sprout that suit their particular needs.
 
-Our [Guide](../../guide/index.qmd) has examples and tutorials on how
+Our [Guide](/docs/guide/index.qmd) has examples and tutorials on how
 each split is used.
 
--   For our CLI, it is placed in the module `sprout/cli/`. Each command
-    imports the relevant functions from `sprout.core`, along with
-    decorators (from other Python packages) to convert the Python code
-    into a CLI program.
+-   A higher-level, opinionated Python implementation of `core`, named
+    `lib` and stored in `seedcase_sprout/lib/`. This module abstracts
+    away and simplified many of the steps and functions available in
+    `core`, with the consequence of being less flexible and less
+    customizable. This module is intended for users who want to use
+    Sprout without having to worry about the finer details of the exact
+    implementation. The internals of the `lib` functions would be strict
+    and opinionated steps for how we envision a data package to be
+    created and managed.
 
--   The web app is in `sprout/app/`. Each page of the web app imports
-    the required functions from `sprout.core`, with functions from other
-    Python packages that convert that code into a web app.
+-   For our CLI, it is placed in the module `seedcase_sprout/cli/`. Each
+    command imports the relevant functions from `seedcase_sprout.core`,
+    along with decorators (from other Python packages) to convert the
+    Python code into a CLI program.
 
--   The web API is in `sprout/api/`. Each endpoint imports the required
-    functions from `sprout.core` with functions from other Python
-    packages that convert that code into a web API. This particular
-    module may not be necessary as many Python packages that create web
-    apps are also able to easily create web APIs from the same or
-    slightly modified code.
+-   The web app is in `seedcase_sprout/app/`. Each page of the web app
+    imports the required functions from `seedcase_sprout.core`, with
+    functions from other Python packages that convert that code into a
+    web app.
+
+-   The web API is in `seedcase_sprout/api/`. Each endpoint imports the
+    required functions from `seedcase_sprout.core` with functions from
+    other Python packages that convert that code into a web API. This
+    particular module may not be necessary as many Python packages that
+    create web apps are also able to easily create web APIs from the
+    same or slightly modified code.

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -48,12 +48,12 @@ each split is used.
     Sprout without having to worry about the finer details of the exact
     implementation. The internals of the `lib` functions would be strict
     and opinionated steps for how we envision a data package to be
-    created and managed.
+    created, structured, and managed.
 
--   For our CLI, it is placed in the module `seedcase_sprout/cli/`. Each
+-   The CLI is placed in the module `seedcase_sprout/cli/`. Each
     command imports the relevant functions from `seedcase_sprout.core`,
     along with decorators (from other Python packages) to convert the
-    Python code into a CLI program.
+    Python code into a CLI.
 
 -   The web app is in `seedcase_sprout/app/`. Each page of the web app
     imports the required functions from `seedcase_sprout.core`, with


### PR DESCRIPTION
## Description

As I was writing the guide on creating data resources and late night swirling thoughts, combined with potential users who would code in Python, I thought that there should actually be Python code that mimicks what the CLI will do... meaning code that has a lot more assumptions and opinions tied to it. Based on discussions we've had over the months, I see a lot of value in having a highly flexible `core`, that would allow us to easily integrate e.g. plugins/extensions, not be tied to the specific folder and file structure we prescribe, and allow others to customize things a lot more to their needs. But there is also a lot of value in having some code that is very opinionated and simple. For instance, not needing to pass around `path_*()` for all functions and just assume "properties will always be the root of the package", etc.

Closes #850 and closes #869

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.
