### PR TITLE
build: :wrench: add GitHub workflow to keep track of Data Package versions

### DIFF
--- a/.github/workflows/check-data-package-version.yml
+++ b/.github/workflows/check-data-package-version.yml
@@ -2,8 +2,8 @@ name: Check Data Package standard version
 
 on:
   schedule:
-    # Runs at midnight on Sundays
-    - cron: 0 0 * * 0
+    # Runs every two months
+    - cron: 0 0 1 */2 *
   workflow_dispatch:
 
 env:
@@ -16,9 +16,11 @@ jobs:
     steps:
       - name: Fetch latest version
         run: |
-          latest_version=$(curl -s https://api.github.com/repos/$DP_REPO/releases/latest | jq -r .tag_name)
+          latest_version=$(gh release view --repo $DP_REPO --json tagName -q .tagName)
           echo "latest_version=$latest_version" >> $GITHUB_ENV
           echo "Latest version is $latest_version"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create an issue if a new version is available
         if: env.latest_version != env.CURRENT_VERSION
@@ -28,10 +30,10 @@ jobs:
             Please check if updating Sprout's copy of the Data Package standard is necessary.
 
             If so:
-            - Replace the old JSON schema of the Data Package standard with the new one downloaded from the website.
-            - Update the current version of \`$DP_REPO\` in the '$GH_WORKFLOW' GitHub workflow."
+              - [ ] Replace the old JSON schema of the Data Package standard with the new one downloaded from the website.
+              - [ ] Update the current version of \`$DP_REPO\` in the '$GH_WORKFLOW' GitHub workflow."
           gh issue create --title "$title" --body "$body"
         env:
-          GH_TOKEN: ${{ secrets.ADD_TO_BOARD }}
+          GH_TOKEN: ${{ secrets.UPDATE_DATAPACKAGE }}
           GH_REPO: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}

--- a/.github/workflows/check-data-package-version.yml
+++ b/.github/workflows/check-data-package-version.yml
@@ -2,12 +2,13 @@ name: Check Data Package standard version
 
 on:
   schedule:
-    - cron: '0 0 * * 0' # Runs at midnight on Sundays
+    # Runs at midnight on Sundays
+    - cron: 0 0 * * 0
   workflow_dispatch:
 
 env:
-  CURRENT_VERSION: "v2.0"
-  DP_REPO: "frictionlessdata/datapackage"
+  CURRENT_VERSION: v2.0
+  DP_REPO: frictionlessdata/datapackage
 
 jobs:
   check-latest-version:

--- a/.github/workflows/check-data-package-version.yml
+++ b/.github/workflows/check-data-package-version.yml
@@ -1,0 +1,36 @@
+name: Check Data Package standard version
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Runs at midnight on Sundays
+  workflow_dispatch:
+
+env:
+  CURRENT_VERSION: "v2.0"
+  DP_REPO: "frictionlessdata/datapackage"
+
+jobs:
+  check-latest-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch latest version
+        run: |
+          latest_version=$(curl -s https://api.github.com/repos/$DP_REPO/releases/latest | jq -r .tag_name)
+          echo "latest_version=$latest_version" >> $GITHUB_ENV
+          echo "Latest version is $latest_version"
+
+      - name: Create an issue if a new version is available
+        if: env.latest_version != env.CURRENT_VERSION
+        run: |
+          title="New \`$DP_REPO\` version available: $latest_version"
+          body="A new version of [\`$DP_REPO\`](https://github.com/$DP_REPO) is available: $latest_version.
+            Please check if updating Sprout's copy of the Data Package standard is necessary.
+
+            If so:
+            - Replace the old JSON schema of the Data Package standard with the new one downloaded from the website.
+            - Update the current version of \`$DP_REPO\` in the '$GH_WORKFLOW' GitHub workflow."
+          gh issue create --title "$title" --body "$body"
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_BOARD }}
+          GH_REPO: ${{ github.repository }}
+          GH_WORKFLOW: ${{ github.workflow }}


### PR DESCRIPTION
## Description

This adds a GitHub workflow for checking for updates in the Data Package standard. If there is an update, an issue is raised.

I tried this in a test repo and it worked, but we'll see if the permissions will work here as well.

I thought this was a not particularly intrusive way of getting updates from the Data Package project, but we can do something else as well. Feel free to change the wording or add more settings to the issue.

Closes #862 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
