### PR TITLE
fix: :bug: compact form of nested properties

### DIFF
--- a/seedcase_sprout/core/properties.py
+++ b/seedcase_sprout/core/properties.py
@@ -30,9 +30,9 @@ class Properties(ABC):
         """
         return asdict(
             obj=self,
-            dict_factory=lambda tuples: dict(
-                tuple for tuple in tuples if tuple[1] is not None
-            ),
+            dict_factory=lambda tuples: {
+                key: value for key, value in tuples if value is not None
+            },
         )
 
 

--- a/seedcase_sprout/core/properties.py
+++ b/seedcase_sprout/core/properties.py
@@ -3,7 +3,7 @@
 # properties file to add more dataclasses and move them into this file.
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass
 from typing import Any, Literal, Self
 from uuid import uuid4
 
@@ -28,30 +28,12 @@ class Properties(ABC):
         Returns:
             A dictionary representation of the object with only non-None values.
         """
-        compact_form = {}
-        for field in fields(self):
-            key = field.name
-            value = get_compact_value(getattr(self, key))
-            if value is not None:
-                compact_form[key] = value
-        return compact_form
-
-
-def get_compact_value(value: Any) -> Any:
-    """Recursively calls `compact_dict` on all nested fields in a `*Properties` object.
-
-    Args:
-        value: The value of a field of a `*Properties` object.
-
-    Returns:
-        The value in a compact form.
-    """
-    if isinstance(value, Properties):
-        return value.compact_dict
-    elif isinstance(value, list):
-        return [get_compact_value(item) for item in value]
-    else:
-        return value
+        return asdict(
+            obj=self,
+            dict_factory=lambda tuples: dict(
+                tuple for tuple in tuples if tuple[1] is not None
+            ),
+        )
 
 
 @dataclass

--- a/tests/core/test_properties.py
+++ b/tests/core/test_properties.py
@@ -63,6 +63,32 @@ def test_compact_dict_preserves_only_non_none_values():
     assert properties.compact_dict == {"name": "package-1", "version": "3.2.1"}
 
 
+def test_compact_dict_removes_none_values_in_nested_objects():
+    """Given properties with a nested structure, should return a dictionary with only
+    non-None values"""
+    properties = PackageProperties(
+        resources=[
+            ResourceProperties(
+                schema=TableSchemaProperties(
+                    fields=[
+                        FieldProperties(
+                            constraints=ConstraintsProperties(
+                                json_schema={"test": "test"}
+                            )
+                        )
+                    ]
+                ),
+            ),
+        ],
+    )
+
+    assert properties.compact_dict == {
+        "resources": [
+            {"schema": {"fields": [{"constraints": {"json_schema": {"test": "test"}}}]}}
+        ]
+    }
+
+
 @patch("seedcase_sprout.core.properties.uuid4", return_value=UUID(int=1))
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1, tzinfo=ZoneInfo("UTC")), tick=False)
 def test_creates_package_properties_with_correct_defaults(mock_uuid):


### PR DESCRIPTION
## Description

This fixes a problem where `compact_dict` was not removing `None` values from nested objects.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
