### PR TITLE
feat: write script to capture overdue reviews of documents

### DIFF
--- a/docs/design/architecture/c4-models.qmd
+++ b/docs/design/architecture/c4-models.qmd
@@ -58,3 +58,5 @@ This diagram shows the components that make up the database and storage containe
 ![C4 Component diagram showing the parts that make up the database and
 storage containers.](images/c4/component-backend.svg)
 :::
+
+<!--Next Review date: 2024-01-01-->

--- a/docs/design/architecture/modular-design.qmd
+++ b/docs/design/architecture/modular-design.qmd
@@ -46,3 +46,5 @@ each split is used.
     module may not be necessary as many Python packages that create web
     apps are also able to easily create web APIs from the same or
     slightly modified code.
+
+<!--Next Review date: 2025-01-01-->

--- a/docs/design/architecture/naming.qmd
+++ b/docs/design/architecture/naming.qmd
@@ -75,3 +75,5 @@ We may also occasionally use "properties" to refer to the file itself.
 | extract | Extract specific information from an object, specifically the properties from a data file. |
 
 : General actions that Sprout can take on objects or files/folders.
+
+<!--Next Review date: 2024-10-01-->

--- a/rs.py
+++ b/rs.py
@@ -1,0 +1,65 @@
+import os
+import re
+from datetime import datetime
+
+# Define the directory containing your documents
+repo_dir = "/Users/au157729/Documents/GitHub/seedcase-sprout"
+
+# Define the pattern to search for the Next Review date in each document
+date_pattern = r"<!--Next Review date:\s*(\d{4}-\d{2}-\d{2})-->"
+
+# Get the current date for comparison
+current_date = datetime.now()
+
+
+# Function to check if the review date has passed
+def has_review_date_passed(review_date_str):
+    try:
+        review_date = datetime.strptime(review_date_str, "%Y-%m-%d")
+        return review_date < current_date
+    except ValueError:
+        # In case the date is malformed, return False
+        return False
+
+
+# Function to search for the Next Review date in each document
+def find_review_dates_in_repo(repo_dir):
+    # List to store files with passed review dates
+    passed_files = []
+
+    # Walk through the repository directory
+    for root, dirs, files in os.walk(repo_dir):
+        for file in files:
+            # Check if the file is a document type you're interested in (e.g., .html, .txt, .xml)
+            if file.endswith(
+                (".html", ".xml", ".txt", ".qmd", ".md")
+            ):  # Adjust extensions as needed
+                file_path = os.path.join(root, file)
+                with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+                    content = f.read()
+
+                    # Search for the review date in the file
+                    match = re.search(date_pattern, content)
+                    if match:
+                        review_date_str = match.group(
+                            1
+                        )  # Extract the date from the comment
+                        if has_review_date_passed(review_date_str):
+                            passed_files.append(
+                                (file_path, review_date_str)
+                            )  # Store both file path and date
+
+    return passed_files
+
+
+# Get the list of documents where the review date has passed
+files_with_passed_reviews = find_review_dates_in_repo(repo_dir)
+
+# Output the list of documents with their review dates
+if files_with_passed_reviews:
+    print("Documents with passed review dates:")
+    for item in files_with_passed_reviews:
+        file_path, review_date = item  # Unpack the tuple
+        print(f"{file_path} (Next Review Date: {review_date})")
+else:
+    print("No documents with passed review dates found.")


### PR DESCRIPTION
added review dates as a test to three documents, two overdue and one not for testing

## Description

This PR adds a first draft of a script which will help us to maintain our documentation and ensure that it is reviewed on a regular basis.

The premise is that we add a comment to all the documents that we would like to include in our regular reviews with a date for next review. This adds a level of flexibility to the review schedule as we can decide for newly created documents (where we are not entirely sure that we have captured everything) that they should be reviewed in three or six months, and for more established documents that they may be fine with a yearly check.

The alternative would be to maintain a list of documents in all repos that we would like to review, or run through everything every half year.

Closes 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Focus for reviewer

This is a first draft, it will need to be changed so that it points to the repo that the script is stored in (I assuming we can't have a script in one repo which checks all of them). 