### PR TITLE
docs: :pencil2: Minor edits to docstrings

### DIFF
--- a/seedcase_sprout/core/check_data_path.py
+++ b/seedcase_sprout/core/check_data_path.py
@@ -8,14 +8,17 @@ from seedcase_sprout.core.not_properties_error import NotPropertiesError
 def check_data_path(properties: dict) -> dict:
     """Checks if the data path in the resource properties is well-formed.
 
+    To be well-formed the data path must have three parts: the root, the resource ID,
+    and the file name. The resource ID must be a number.
+
     Args:
         properties: The resource properties to check.
 
     Returns:
-        The properties, if the data path is well formed.
+        The properties if the data path is well-formed.
 
     Raises:
-        NotPropertiesError: If the data path is not well formed.
+        NotPropertiesError: If the data path is not well-formed.
     """
     data_path = Path(properties.get("path", ""))
     if len(data_path.parts) != 3 or not data_path.parts[1].isdigit():

--- a/seedcase_sprout/core/check_is_dir.py
+++ b/seedcase_sprout/core/check_is_dir.py
@@ -2,10 +2,10 @@ from pathlib import Path
 
 
 def check_is_dir(path: Path) -> Path:
-    """Verifies whether the directory given by the path exists or not.
+    """Checks whether the path exists and is a directory.
 
     Args:
-        path: The path to verify
+        path: The path to check.
 
     Returns:
         The path if it is a directory.
@@ -14,6 +14,6 @@ def check_is_dir(path: Path) -> Path:
         NotADirectoryError: If path either doesn't exist or isn't a directory.
     """
     if not path.is_dir():
-        raise NotADirectoryError(f"{path} either isn't a directory or doesn't exist.")
+        raise NotADirectoryError(f"{path} either doesn't exist or isn't a directory.")
 
     return path

--- a/seedcase_sprout/core/check_is_dir.py
+++ b/seedcase_sprout/core/check_is_dir.py
@@ -7,11 +7,11 @@ def check_is_dir(path: Path) -> Path:
     Args:
         path: The path to verify
 
-    Raises:
-        NotADirectoryError: When the directory in the path doesn't exist.
-
     Returns:
-        A Path object if it is a directory.
+        The path if it is a directory.
+
+    Raises:
+        NotADirectoryError: If path either doesn't exist or isn't a directory.
     """
     if not path.is_dir():
         raise NotADirectoryError(f"{path} either isn't a directory or doesn't exist.")

--- a/seedcase_sprout/core/check_is_file.py
+++ b/seedcase_sprout/core/check_is_file.py
@@ -7,11 +7,11 @@ def check_is_file(path: Path) -> Path:
     Args:
         path: The path to verify.
 
-    Raises:
-        FileNotFound: When the file in the path doesn't exist.
-
     Returns:
         A Path object if it is a file.
+
+    Raises:
+        FileNotFound: If the file in the path doesn't exist or isn't a file.
     """
     if not path.is_file():
         raise FileNotFoundError(f"{path} is not a file.")

--- a/seedcase_sprout/core/check_is_file.py
+++ b/seedcase_sprout/core/check_is_file.py
@@ -2,13 +2,13 @@ from pathlib import Path
 
 
 def check_is_file(path: Path) -> Path:
-    """Verifies whether the file given by the path exists or not.
+    """Checks whether the file given by the path exists and is a file.
 
     Args:
-        path: The path to verify.
+        path: The path to check.
 
     Returns:
-        A Path object if it is a file.
+        A path to the file if the path refers to a file.
 
     Raises:
         FileNotFound: If the file in the path doesn't exist or isn't a file.

--- a/seedcase_sprout/core/check_is_package_dir.py
+++ b/seedcase_sprout/core/check_is_package_dir.py
@@ -5,13 +5,13 @@ from seedcase_sprout.core.get_ids import get_ids
 
 
 def check_is_package_dir(path: Path) -> Path:
-    """Verifies that the path is a directory in the package directory.
+    """Checks that the path is a directory within the package directory.
 
     Args:
-        path: Path to verify.
+        path: The path to verify.
 
     Returns:
-        Path, if path is a directory.
+        The path if it's a directory within the package directory.
 
     Raises:
         NotADirectoryError: If the path is not a directory. The error message

--- a/seedcase_sprout/core/check_is_resource_dir.py
+++ b/seedcase_sprout/core/check_is_resource_dir.py
@@ -8,10 +8,10 @@ def check_is_resource_dir(path: Path) -> Path:
     """Verifies that the path is a directory in the resources folder.
 
     Args:
-        path: Path to verify.
+        path: The Path to verify.
 
     Returns:
-        Path, if path is a directory.
+        Path if path is a directory.
 
     Raises:
         NotADirectoryError: If the path is not a directory. The error message

--- a/seedcase_sprout/core/check_is_resource_dir.py
+++ b/seedcase_sprout/core/check_is_resource_dir.py
@@ -5,10 +5,10 @@ from seedcase_sprout.core.get_ids import get_ids
 
 
 def check_is_resource_dir(path: Path) -> Path:
-    """Verifies that the path is a directory in the resources folder.
+    """Checks that the path is a directory in the resources folder.
 
     Args:
-        path: The Path to verify.
+        path: The path to check.
 
     Returns:
         Path if path is a directory.

--- a/seedcase_sprout/core/check_is_resource_dir.py
+++ b/seedcase_sprout/core/check_is_resource_dir.py
@@ -11,7 +11,7 @@ def check_is_resource_dir(path: Path) -> Path:
         path: The path to check.
 
     Returns:
-        Path if path is a directory.
+        The path if it's a directory.
 
     Raises:
         NotADirectoryError: If the path is not a directory. The error message

--- a/seedcase_sprout/core/check_is_supported_format.py
+++ b/seedcase_sprout/core/check_is_supported_format.py
@@ -23,9 +23,9 @@ class UnsupportedFormatError(Exception):
         """Initialises UnsupportedFormatError.
 
         Args:
-            format: the extension of the unsupported format
-            *args: non-keyword arguments
-            **kwargs: keyword arguments
+            format: The extension of the unsupported format
+            *args: Non-keyword arguments
+            **kwargs: Keyword arguments
         """
         message = (
             f"File format '{format}' is not supported. Sprout currently "
@@ -38,13 +38,13 @@ def check_is_supported_format(path: Path) -> Path:
     """Checks that the format of the file given by the path is supported by Sprout.
 
     Args:
-        path: the path pointing to the file to check
-
-    Raises:
-        UnsupportedFormatError: raised if the file format is not supported
+        path: The path pointing to the file to check
 
     Returns:
-        the path pointing to the file, if the file format is supported
+        The path pointing to the file, if the file format is supported
+
+    Raises:
+        UnsupportedFormatError: If the file format is not supported
     """
     format = path.suffix[1:]
     if format not in SUPPORTED_FORMATS:

--- a/seedcase_sprout/core/create_dirs.py
+++ b/seedcase_sprout/core/create_dirs.py
@@ -10,7 +10,7 @@ def create_dir(path: Path) -> Path:
         path: The path pointing to the new directory to create
 
     Returns:
-        path to the newly created directory.
+        The path to the newly created directory.
     """
     path.mkdir(parents=True)
     return path

--- a/seedcase_sprout/core/create_id_path.py
+++ b/seedcase_sprout/core/create_id_path.py
@@ -5,10 +5,10 @@ def create_id_path(path: Path, id: int) -> Path:
     """Create a path for a new package or resource.
 
     Args:
-        path: Path to the package folder or the resources folder within the package
-        id: ID of the package or resource
+        path: The path to the package folder or the resources folder within the package
+        id: The ID of the package or resource
 
     Returns:
-        A path to the package or resource
+        The path to the package or resource
     """
     return path / f"{id}"

--- a/seedcase_sprout/core/create_next_id.py
+++ b/seedcase_sprout/core/create_next_id.py
@@ -2,7 +2,7 @@ def create_next_id(ids: list[int]) -> int:
     """Creates the next ID in a sequence, given a list of existing IDs. Starts at 1.
 
     Args:
-        ids: A list of existing IDs.
+        ids: The list of existing IDs.
 
     Returns:
         The newly generated ID.

--- a/seedcase_sprout/core/create_package_structure.py
+++ b/seedcase_sprout/core/create_package_structure.py
@@ -25,8 +25,8 @@ def create_package_structure(path: Path) -> list[Path]:
             to provide the correct path location.
 
     Returns:
-        A list of paths to the two created files, the datapackage.json and the
-            README.md, as well as one created `resources/` folder.
+        A list of paths to the two created files, datapackage.json and
+            README.md, and the created folder `resources/`.
 
     Raises:
         NotADirectoryError: If the directory in the path doesn't exist.

--- a/seedcase_sprout/core/create_properties_path.py
+++ b/seedcase_sprout/core/create_properties_path.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 
 def create_properties_path(path: Path) -> Path:
-    """Returns the path to the datapackage.json file of the package.
+    """Creates the path to the package's properties file.
 
     Args:
-        path: the path to the package folder
+        path: The path to the package folder.
 
     Returns:
-        the path to datapackage.json
+        The path to the properties file.
     """
     return path / "datapackage.json"

--- a/seedcase_sprout/core/create_raw_file_name.py
+++ b/seedcase_sprout/core/create_raw_file_name.py
@@ -5,7 +5,7 @@ from seedcase_sprout.core.get_iso_timestamp import get_compact_iso_timestamp
 
 
 def create_raw_file_name(path: Path) -> str:
-    """Generates a unique filename for a raw file.
+    """Creates a unique filename for a raw file.
 
     Args:
         path: The path to the raw file to extract the original extension from.

--- a/seedcase_sprout/core/create_readme_path.py
+++ b/seedcase_sprout/core/create_readme_path.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 
 def create_readme_path(path: Path) -> Path:
-    """Returns the path to the README of the specified package.
+    """Creates the path to the README of the specified package.
 
     Args:
-        path: the path to the package folder
+        path: The path to the package folder.
 
     Returns:
-        the path to the package README
+        The path to the package's README.
     """
     return path / "README.md"

--- a/seedcase_sprout/core/create_readme_text.py
+++ b/seedcase_sprout/core/create_readme_text.py
@@ -1,5 +1,5 @@
 def create_readme_text(properties: dict) -> str:
-    """Creates a json object containing the README text.
+    """Creates a string containing the README text.
 
     Args:
       properties: An object containing the package and resource properties.

--- a/seedcase_sprout/core/create_readme_text.py
+++ b/seedcase_sprout/core/create_readme_text.py
@@ -1,11 +1,11 @@
 def create_readme_text(properties: dict) -> str:
-    """Create a json object containing the readme text.
+    """Creates a json object containing the README text.
 
     Args:
       properties: An object containing the package and resource properties.
 
     Returns:
-      A string for the README text
+      A string with the README text based on the properties.
     """
     # TODO: Finish this once Properties have been finished.
     # resources = # Python code to convert the resource details in the dict as

--- a/seedcase_sprout/core/create_relative_resource_data_path.py
+++ b/seedcase_sprout/core/create_relative_resource_data_path.py
@@ -2,13 +2,13 @@ from pathlib import Path
 
 
 def create_relative_resource_data_path(path: Path) -> Path:
-    """Create a relative path to the resource data file.
+    """Creates a relative path to the resource data file.
 
     Args:
-        path: Absolute path to the folder of a specific resource
+        path: The absolute path to the folder of a specific resource.
 
     Returns:
-        Relative path from the package root to the resource data file
+        The relative path from the package root to the resource data file.
             E.g., "resources/1/data.parquet"
     """
     return Path(*path.parts[-2:]) / "data.parquet"

--- a/seedcase_sprout/core/create_relative_resource_data_path.py
+++ b/seedcase_sprout/core/create_relative_resource_data_path.py
@@ -9,6 +9,6 @@ def create_relative_resource_data_path(path: Path) -> Path:
 
     Returns:
         Relative path from the package root to the resource data file
-        E.g., "resources/1/data.parquet"
+            E.g., "resources/1/data.parquet"
     """
     return Path(*path.parts[-2:]) / "data.parquet"

--- a/seedcase_sprout/core/create_resource_properties.py
+++ b/seedcase_sprout/core/create_resource_properties.py
@@ -29,13 +29,13 @@ def create_resource_properties(path: Path, properties: dict) -> dict:
             See the `ResourceProperties` help documentation for details
             on what can or needs to be filled in.
 
+    Returns:
+        the properties object, verified and updated
+
     Raises:
         NotADirectoryError: if path does not point to a directory.
         NotPropertiesError: if properties are not correct Frictionless
             resource properties.
-
-    Returns:
-        the properties object, verified and updated
     """
     check_is_dir(path)
     verify_properties_are_well_formed(properties, ResourceError.type)

--- a/seedcase_sprout/core/create_resource_properties.py
+++ b/seedcase_sprout/core/create_resource_properties.py
@@ -20,21 +20,21 @@ def create_resource_properties(path: Path, properties: dict) -> dict:
     them to be added to the `datapackage.json` file.
 
     Args:
-        path: the path to the resource `id` folder; use `path_resource()`
+        path: The path to the resource `id` folder; use `path_resource()`
             to provide the correct path or use the output of
             `create_resource_structure()`.
-        properties: the properties of the resource; must be given as a
+        properties: The properties of the resource; must be given as a
             JSON object following the Data Package specification; use
             the `ResourceProperties` class to provide the correct fields.
             See the `ResourceProperties` help documentation for details
             on what can or needs to be filled in.
 
     Returns:
-        the properties object, verified and updated
+        The properties object, verified and updated
 
     Raises:
-        NotADirectoryError: if path does not point to a directory.
-        NotPropertiesError: if properties are not correct Frictionless
+        NotADirectoryError: If path does not point to a directory.
+        NotPropertiesError: If properties are not correct Frictionless
             resource properties.
     """
     check_is_dir(path)

--- a/seedcase_sprout/core/create_resource_raw_path.py
+++ b/seedcase_sprout/core/create_resource_raw_path.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 
 def create_resource_raw_path(path: Path) -> Path:
-    """Create a path to the raw directory for a resource.
+    """Creates a path to the raw directory for a resource.
 
     Args:
-        path: Directory to create the new raw directory in.
+        path: The directory to create the new raw directory in.
 
     Returns:
-        A path to the folder.
+        The path to the resource's raw folder.
     """
     return path / "raw"

--- a/seedcase_sprout/core/create_resource_structure.py
+++ b/seedcase_sprout/core/create_resource_structure.py
@@ -23,8 +23,8 @@ def create_resource_structure(path: Path) -> list[Path]:
 
     Returns:
        A list of the two created directories:
-         - A path to the resource directory and
-         - A path to the raw data directory.
+          - A path to the resource directory and
+          - A path to the raw data directory.
 
     Raises:
        NotADirectoryError: If path is not an existing directory.

--- a/seedcase_sprout/core/create_resource_structure.py
+++ b/seedcase_sprout/core/create_resource_structure.py
@@ -9,7 +9,7 @@ from seedcase_sprout.core.get_ids import get_ids
 
 
 def create_resource_structure(path: Path) -> list[Path]:
-    """Create the directory structure of a new resource.
+    """Creates the directory structure of a new resource.
 
     This is the first function to use to set up the structure for a data
     resource. It creates the paths for a new data resource in a specific

--- a/seedcase_sprout/core/create_root_path.py
+++ b/seedcase_sprout/core/create_root_path.py
@@ -7,6 +7,6 @@ def create_root_path() -> Path:
     """Creates the path to Sprout root.
 
     Returns:
-        A Path with the Sprout root directory tied to the user.
+        The path with the Sprout root directory tied to the user.
     """
     return user_data_path("sprout")

--- a/seedcase_sprout/core/edit_package_properties.py
+++ b/seedcase_sprout/core/edit_package_properties.py
@@ -37,9 +37,9 @@ def edit_package_properties(path: Path, properties: dict) -> dict:
             dictionary. See `help(PackageProperties)` for details on how to use it.
 
     Returns:
-        The updated package properties as a Python dictionary that mimicks the
-        JSON structure. Use `write_package_properties()` to save it back to the
-        `datapackage.json` file.
+        The updated package properties as a Python dictionary that mimics the
+            JSON structure. Use `write_package_properties()` to save it back to the
+            `datapackage.json` file.
 
     Raises:
         FileNotFound: If the `datapackage.json` file doesn't exist.

--- a/seedcase_sprout/core/edit_property_field.py
+++ b/seedcase_sprout/core/edit_property_field.py
@@ -8,11 +8,11 @@ def edit_property_field(properties: dict, field: str, value: any) -> dict:
         field: the name of the field to update
         value: the value to assign to the field
 
-    Raises:
-        KeyError: if the specified field does not exist in properties
-
     Returns:
         the updated properties object
+
+    Raises:
+        KeyError: if the specified field does not exist in properties
     """
     if field not in properties:
         raise KeyError(f"Field '{field}' does not exist in properties {properties}.")

--- a/seedcase_sprout/core/edit_property_field.py
+++ b/seedcase_sprout/core/edit_property_field.py
@@ -1,18 +1,16 @@
 def edit_property_field(properties: dict, field: str, value: any) -> dict:
-    """Updates properties by setting the specified field to the specified value.
-
-    The field must exist on the properties object.
+    """Edits properties by setting the specified field to the specified value.
 
     Args:
-        properties: the properties to update
-        field: the name of the field to update
-        value: the value to assign to the field
+        properties: The properties to edit.
+        field: The name of the field to edit.
+        value: The value to assign to the field.
 
     Returns:
-        the updated properties object
+        The updated properties object.
 
     Raises:
-        KeyError: if the specified field does not exist in properties
+        KeyError: If the specified field does not exist in the properties.
     """
     if field not in properties:
         raise KeyError(f"Field '{field}' does not exist in properties {properties}.")

--- a/seedcase_sprout/core/extract_properties_from_file.py
+++ b/seedcase_sprout/core/extract_properties_from_file.py
@@ -4,12 +4,12 @@ from frictionless import describe
 
 
 def extract_properties_from_file(path: Path) -> dict:
-    """Extracts resource properties from the provided data file.
+    """Extracts the resource properties from the provided data file.
 
     Args:
-        path: the path pointing to the data file
+        path: The path pointing to the data file.
 
     Returns:
-        a dictionary of resource properties
+        The dictionary of the resource properties.
     """
     return describe(path).to_dict()

--- a/seedcase_sprout/core/get_ids.py
+++ b/seedcase_sprout/core/get_ids.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 
 def get_ids(path: Path) -> list[int]:
-    """Get ids of existing resources or packages in a directory.
+    """Gets the ids of existing resources or packages in a directory.
 
     Args:
-        path: Directory to search for IDs.
+        path: The directory to search for IDs.
 
     Returns:
         A list of integers representing the ids of the subdirectories.
@@ -22,13 +22,13 @@ def get_ids(path: Path) -> list[int]:
 
 
 def get_number_from_dir(path: Path) -> int | None:
-    """Get only the number from directory.
+    """Gets only the number from the directory.
 
     Args:
-        path: Directory to extract the number from.
+        path: The directory to extract the number from.
 
     Returns:
-        A single integer or None if the directory name does not contain a number.
+        A single integer if the directory contains a number. Otherwise, None.
     """
     dir_name = path.name
     if re.match(r"^\d+$", dir_name):

--- a/seedcase_sprout/core/get_ids.py
+++ b/seedcase_sprout/core/get_ids.py
@@ -10,7 +10,7 @@ def get_ids(path: Path) -> list[int]:
 
     Returns:
         A list of integers representing the ids of the subdirectories.
-        If no IDs are found, an empty list is returned.
+            If no IDs are found, an empty list is returned.
     """
     # Keep only directories
     dirs = list(path.glob("*/"))

--- a/seedcase_sprout/core/get_iso_timestamp.py
+++ b/seedcase_sprout/core/get_iso_timestamp.py
@@ -2,18 +2,18 @@ from datetime import datetime
 
 
 def get_iso_timestamp() -> str:
-    """Generates an ISO timestamp compliant with the Data Package spec.
+    """Gets the current ISO timestamp compliant with the Data Package spec.
 
     Returns:
-        The timestamp as a string. E.g. `2024-05-14T05:00:01+00:00`.
+        The current ISO timestamp as a string. E.g. `2024-05-14T05:00:01+00:00`.
     """
     return datetime.now().astimezone().isoformat(timespec="seconds")
 
 
 def get_compact_iso_timestamp() -> str:
-    """Generates a compact ISO timestamp.
+    """Gets the current timestamp in a compact ISO format.
 
     Returns:
-        The timestamp as a string. E.g. `2024-05-14T050000Z`.
+        The current compact ISO timestamp as a string. E.g. `2024-05-14T050000Z`.
     """
     return datetime.now().strftime("%Y-%m-%dT%H%M%SZ")

--- a/seedcase_sprout/core/get_json_from_url.py
+++ b/seedcase_sprout/core/get_json_from_url.py
@@ -2,13 +2,13 @@ import requests
 
 
 def get_json_from_url(url: str) -> dict:
-    """Scrapes a URL with a JSON object.
+    """Gets the JSON object from a URL.
 
     Args:
-        url: URL with JSON object to scrape.
+        url: A URL with a JSON object to scrape.
 
     Returns:
-        A dictionary with the JSON object from the URL.
+        The JSON object from the URL as a dictionary.
 
     Raises:
         json.JSONDecodeError: If the URL does not contain a JSON object.

--- a/seedcase_sprout/core/get_root_envvar.py
+++ b/seedcase_sprout/core/get_root_envvar.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 
 def get_root_envvar() -> Path | None:
-    """Get the root environment variable SPROUT ROOT if it exists.
+    """Gets the root environment variable SPROUT ROOT if it exists.
 
     Returns:
-        A Path object containing SPROUT_ROOT if it is set, otherwise None.
+        The path containing SPROUT_ROOT if it is set, otherwise None.
     """
     root = getenv("SPROUT_ROOT")
     return Path(root) if root else None

--- a/seedcase_sprout/core/path_package_functions.py
+++ b/seedcase_sprout/core/path_package_functions.py
@@ -8,39 +8,39 @@ from seedcase_sprout.core.path_sprout_root import path_sprout_root
 
 
 def path_package(package_id: int) -> Path:
-    """Gets the absolute path to the specific package folder.
+    """Gets the absolute path to the specified package.
 
     Args:
-        package_id: The ID of the package to get the folder path for.
+        package_id: The ID of the package.
 
     Returns:
-        The absolute path to the package folder.
+        The absolute path to the specified package.
     """
     path = path_packages() / str(package_id)
     return check_is_package_dir(path)
 
 
 def path_package_database(package_id: int) -> Path:
-    """Gets the absolute path to a given package's SQL database.
+    """Gets the absolute path to the specified package's SQL database.
 
     Args:
-        package_id: ID of the package.
+        package_id: The ID of the package.
 
     Returns:
-        A Path to the package's database.
+        The absolute path to the specified package's database.
     """
     path = path_package(package_id) / "database.sql"
     return check_is_file(path)
 
 
 def path_package_properties(package_id: int) -> Path:
-    """Gets the absolute path to a given package's properties file.
+    """Gets the absolute path to the specified package's properties file.
 
     Args:
-        package_id: ID of the package.
+        package_id: The ID of the package.
 
     Returns:
-        A Path to the properties file.
+        The absolute path to the specified package's properties file.
     """
     path = path_package(package_id) / "datapackage.json"
     return check_is_file(path)
@@ -50,7 +50,7 @@ def path_packages() -> Path:
     """Gets the absolute path to the packages folder.
 
     Returns:
-        A Path to the packages folder.
+        The absolute path to the packages folder.
 
     Raises:
         NotADirectoryError: If the packages folder doesn't exist.

--- a/seedcase_sprout/core/path_resource_functions.py
+++ b/seedcase_sprout/core/path_resource_functions.py
@@ -7,56 +7,56 @@ from seedcase_sprout.core.check_is_resource_dir import check_is_resource_dir
 
 
 def path_resource(package_id: int, resource_id: int) -> Path:
-    """Gets the absolute path to a given resource of a given package.
+    """Gets the absolute path to the specified resource.
 
     Args:
-        package_id: ID of the package.
-        resource_id: ID of the resource.
+        package_id: The ID of the package.
+        resource_id: The ID of the resource.
 
     Returns:
-        A Path to the resource.
+        The absolute path to the specified resource.
     """
     path = path_resources(package_id) / str(resource_id)
     return check_is_resource_dir(path)
 
 
 def path_resource_data(package_id: int, resource_id: int) -> Path:
-    """Gets the absolute path to a given resource's data (i.e., parquet) file.
+    """Gets the absolute path to the specified resource's data (i.e., parquet) file.
 
     Args:
         package_id: ID of the package.
         resource_id: ID of the resource.
 
     Returns:
-        A Path to the resource's data file.
+        The absolute path the specified resource's data file.
     """
     path = path_resource(package_id, resource_id) / "data.parquet"
     return check_is_file(path)
 
 
 def path_resource_raw(package_id: int, resource_id: int) -> Path:
-    """Gets the absolute path to a given resource's raw folder.
+    """Gets the absolute path to the specified resource's raw folder.
 
     Args:
-        package_id: ID of the package.
-        resource_id: ID of the resource.
+        package_id: The ID of the package.
+        resource_id: The ID of the resource.
 
     Returns:
-        A Path to the resource's raw folder.
+        The absolute path to the specified resource's raw folder.
     """
     path = path_resource(package_id, resource_id) / "raw"
     return check_is_dir(path)
 
 
 def path_resource_raw_files(package_id: int, resource_id: int) -> list[Path]:
-    """Gets the absolute path to the raw files of  a resource.
+    """Gets the absolute path to the raw files of the specified resource.
 
     Args:
-        package_id: ID of the package.
-        resource_id: ID of the resource.
+        package_id: The ID of the package.
+        resource_id: The ID of the resource.
 
     Returns:
-        A list of Paths to the raw files of the resource.
+        A list of paths to the specified resource's raw files.
 
     Raises:
         NotADirectoryError: If the package_id doesn't exist or the resource_id doesn't
@@ -66,13 +66,13 @@ def path_resource_raw_files(package_id: int, resource_id: int) -> list[Path]:
 
 
 def path_resources(package_id: int) -> Path:
-    """Gets the absolute path to resources of a given package.
+    """Gets the absolute path to the resources of the specified package.
 
     Args:
-        package_id: ID of the package to get the resource path from."
+        package_id: The ID of the package.
 
     Returns:
-        A Path to the resources within the package.
+        The absolute path to the resources within the specified package.
     """
     path = path_package(package_id) / "resources"
     check_is_dir(path)

--- a/seedcase_sprout/core/path_sprout_root.py
+++ b/seedcase_sprout/core/path_sprout_root.py
@@ -5,9 +5,9 @@ from seedcase_sprout.core.get_root_envvar import get_root_envvar
 
 
 def path_sprout_root() -> Path:
-    """Get Sprout's root path.
+    """Gets Sprout's root path.
 
     Returns:
-        A Path to Sprout's root directory.
+        The path to Sprout's root directory.
     """
     return get_root_envvar() or create_root_path()

--- a/seedcase_sprout/core/properties.py
+++ b/seedcase_sprout/core/properties.py
@@ -45,9 +45,9 @@ class ContributorProperties(Properties):
         path (str | None): A fully qualified URL pointing to a relevant
             location online for the contributor.
         email (str | None): An email address.
-        given_name (str | None): A string containing the name a person has been
+        given_name (str | None): The name a person has been
             given, if the contributor is a person.
-        family_name (str | None): A string containing the familial name that a person
+        family_name (str | None): The familial name that a person
             inherits, if the contributor is a person.
         organization (str | None): An organizational affiliation for this
             contributor.

--- a/seedcase_sprout/core/read_json.py
+++ b/seedcase_sprout/core/read_json.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def read_json(path: Path) -> list | dict:
-    """Loads the contents of a JSON file into an object.
+    """Reads the contents of a JSON file into an object.
 
     Args:
         path: The path to the file to load.

--- a/seedcase_sprout/core/write_file.py
+++ b/seedcase_sprout/core/write_file.py
@@ -8,8 +8,8 @@ def write_file(string: str, path: Path) -> Path:
     If the file already exists, it will be overwritten.
 
     Args:
-        string: Content to be written to the file.
-        path: Path of the file to be created, including file name and extension.
+        string: The content to be written to the file.
+        path: A path of the file to be created, including the file name and extension.
 
     Returns:
         A path to the file that was created.

--- a/seedcase_sprout/core/write_json.py
+++ b/seedcase_sprout/core/write_json.py
@@ -12,7 +12,7 @@ def write_json(json_object: list | dict, path: Path) -> Path:
         path: The path to the file with name and extension.
 
     Returns:
-        The path to the newly created file.
+        The path to the newly created JSON file.
 
     Raises:
         FileNotFoundError: If the parent folder of the file doesn't exist.

--- a/seedcase_sprout/core/write_resource_properties.py
+++ b/seedcase_sprout/core/write_resource_properties.py
@@ -9,7 +9,7 @@ from seedcase_sprout.core.write_json import write_json
 
 
 def write_resource_properties(path: Path, resource_properties: dict) -> Path:
-    """Adds the specified resource properties to the `datapackage.json` file.
+    """Wrties the specified resource properties to the `datapackage.json` file.
 
     This functions verifies `resource_properties`, and if a
     resource with that ID is already present on the package, the properties of the


### PR DESCRIPTION
## Description

As a first step to fixing the quartodoc build (#927 ), this PR adds some minor text edits to the docstrings within `core` to follow the Google style and to be more aligned. 

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [ ] Added or updated tests
- [X] Updated documentation
- [ ] Ran `just run-all`
