### PR TITLE
docs: 🐛  enable quartodoc dynamic lookup

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -74,6 +74,7 @@ quartodoc:
   dir: "docs/reference"
   package: "seedcase_sprout"
   parser: google
+  dynamic: true
   renderer:
     style: markdown
     table_style: description-list

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -79,6 +79,7 @@ quartodoc:
     table_style: description-list
   sections:
     - title: "Core functions"
+      desc: "Core functions that support the creation and management of data packages and data resources."
 
     - subtitle: "Data package functions"
       desc: "Functions to work with and manage data packages, but not the data resources within them."

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -82,46 +82,50 @@ quartodoc:
 
     - subtitle: "Data package functions"
       desc: "Functions to work with and manage data packages, but not the data resources within them."
+      package: "seedcase_sprout.core"
       contents:
-        - core.create_package_structure
-        - core.edit_package_properties
+        - create_package_structure
+        - edit_package_properties
 
     - subtitle: "Data resource functions"
       desc: "Functions to work with and manage data resources found within a data package."
+      package: "seedcase_sprout.core"
       contents:
-        - core.write_resource_properties
-        - core.create_resource_properties
-        - core.create_resource_structure
+        - write_resource_properties
+        - create_resource_properties
+        - create_resource_structure
 
     - subtitle: "Property dataclasses"
       desc: "Dataclasses that support creating correct data package properties."
+      package: "seedcase_sprout.core"
       contents:
-        - core.ConstraintsProperties
-        - core.ContributorProperties
-        - core.FieldProperties
-        - core.LicenseProperties
-        - core.MissingValueProperties
-        - core.PackageProperties
-        - core.ReferenceProperties
-        - core.ResourceProperties
-        - core.SourceProperties
-        - core.TableDialectProperties
-        - core.TableSchemaForeignKeyProperties
-        - core.TableSchemaProperties
+        - ConstraintsProperties
+        - ContributorProperties
+        - FieldProperties
+        - LicenseProperties
+        - MissingValueProperties
+        - PackageProperties
+        - ReferenceProperties
+        - ResourceProperties
+        - SourceProperties
+        - TableDialectProperties
+        - TableSchemaForeignKeyProperties
+        - TableSchemaProperties
 
     - subtitle: "Path functions"
       desc: "Functions to support providing the correct file paths to data package and data resource functions."
+      package: "seedcase_sprout.core"
       contents:
-        - core.path_package
-        - core.path_package_database
-        - core.path_package_properties
-        - core.path_packages
-        - core.path_resource
-        - core.path_resource_data
-        - core.path_resource_raw
-        - core.path_resource_raw_files
-        - core.path_resources
-        - core.path_sprout_root
+        - path_package
+        - path_package_database
+        - path_package_properties
+        - path_packages
+        - path_resource
+        - path_resource_data
+        - path_resource_raw
+        - path_resource_raw_files
+        - path_resources
+        - path_sprout_root
 
 metadata-files:
   - docs/reference/_sidebar.yml


### PR DESCRIPTION
## Description

This fixes the issue of quartodoc documenting the module/file instead of the function within the file with the same name. 

By actually loading the package (what they call "dynamic lookup"), I think `core`'s namespace (i.e., `__all__` in `__init__.py`) becomes available for quartodoc. This is instead of quartodoc using static analysis to look up the objects we want to document (which is the default).

It now looks like this for `create_package_structure` locally: 
![image](https://github.com/user-attachments/assets/fccc6419-ac6e-4b8d-ba56-c6d7dc334a5a)
<img https://github.com/user-attachments/assets/fccc6419-ac6e-4b8d-ba56-c6d7dc334a5a)

Instead of: 
![image](https://github.com/user-attachments/assets/fd79732a-098b-4ee6-af58-25aa4482b692)

Closes #944 
Closes #943 

Note: This is a stacked PR on #942 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [X] Updated documentation
- [ ] Ran `just run-all`
