### PR TITLE
docs: :sparkles: add signature annotations to reference docs

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -78,6 +78,7 @@ quartodoc:
   renderer:
     style: markdown
     table_style: description-list
+    show_signature_annotations: true
   sections:
     - title: "Core functions"
       desc: "Core functions that support the creation and management of data packages and data resources."


### PR DESCRIPTION
## Description

This PR adds type annotations to the "signature" of the functions in the reference docs. 

Like this: 
![image](https://github.com/user-attachments/assets/21b4f3c3-3a37-40ba-a8cd-a2cc98229e63)

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Updated documentation
