### PR TITLE
chore: 🔥 remove `path_package_database()`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -120,7 +120,6 @@ quartodoc:
       package: "seedcase_sprout.core"
       contents:
         - path_package
-        - path_package_database
         - path_package_properties
         - path_packages
         - path_resource

--- a/docs/design/architecture/naming.qmd
+++ b/docs/design/architecture/naming.qmd
@@ -42,7 +42,7 @@ We may also occasionally use "properties" to refer to the file itself.
 | properties or property | Metadata about a package or resource. |
 | file structure or structure | The file and folder structure of a package. |
 | path | A file path listing the location of folders or files that Sprout interacts with. |
-| data | The data file within a resource. Within Sprout, this includes the table in the database, the Parquet file, as well as raw files. |
+| data | The data file within a resource. Within Sprout, this includes the Parquet file and raw files. |
 | identifier | A unique identifier for a package or resource, denoted as `id`. |
 
 : General objects used throughout Sprout.
@@ -55,7 +55,6 @@ We may also occasionally use "properties" to refer to the file itself.
 | raw data file | A compressed raw data file format, such as a `.zip`, `.gzip`, or `.tar.gz` file. |
 | JSON | The main way we save and pass information around on the package's or resource's properties. |
 | Parquet | A columnar, efficient storage file format that we use to save data within a resource. |
-| SQLite | A relational database file format that we use to contain all data resources in a package. |
 
 : Specific files and folders used within or output by Sprout.
 

--- a/docs/design/interface/outputs.qmd
+++ b/docs/design/interface/outputs.qmd
@@ -26,10 +26,10 @@ When a user starts using Sprout to structure their data, that data will
 form a [Data Package](https://datapackage.org) (from the Frictionless
 Data standard). A data package is called many things in other fields.
 For instance it could be a "cohort study data", a "data resource", a
-database, a clinical trial dataset, a dataset, a study dataset, simply
-"data", or any other combination of words that include the word data. To
-keep it consistent with the Frictionless Data standard, we name it a
-data package.
+clinical trial dataset, a dataset, a study dataset, simply "data", or
+any other combination of words that include the word data. To keep it
+consistent with the Frictionless Data standard, we name it a data
+package.
 
 A data package consists of one or more files (called data resources)
 that contain data specific to a given set of conditions. For instance, a
@@ -116,23 +116,6 @@ Sprout creates and uses these files:
     serve potentially as the basis for displaying information for a data
     package's landing page in the Sprout web app.
 
-`./database.sqlite`
-
-:   This file contains all the data in the data package as a
-    [SQLite](https://decisions.seedcase-project.org/why-sqlite/)
-    database. Each relational table within represents one data resource.
-    The SQLite database is used because it is a lightweight, serverless,
-    and self-contained database that is easy to use and manage. It is
-    also a common database format that is used in many applications and
-    is easy to export to other database formats. The file is only
-    described within the `datapackage.json` file and is not classified
-    as a data resource, so the database file cannot be used by software
-    that follows the Frictionless Data standard. We use and provide it
-    because of the features that formal databases provide, like
-    indexing, querying, and data integrity. The `data.parquet` file
-    described below will be the data resource that is linked within the
-    `datapackage.json` file.
-
 `./resources/<id>/raw/<timestamp>-<uuid>.<extension>.gzip`
 
 :   These are compressed raw data files associated with a specific
@@ -150,16 +133,7 @@ Sprout creates and uses these files:
 :   When a user creates a data resource and adds or updates data in the
     resource, all resource data is processed and stored in the
     [Parquet](https://decisions.seedcase-project.org/why-parquet/) data
-    format (if it is tabular data). The reason there is both a Parquet
-    file as well as a table in the SQLite database is the way the
-    [Frictionless Data Package](https://datapackage.org/) specification
-    describes and sets data resources. The specification requires either
-    a path value or a data value to be set for a data resource, but does
-    not allow for setting a table in a database as a value. So
-    interoperability of the data package is achieved by providing the
-    Parquet file, rather than the SQLite database. In this way, we use
-    both the Parquet data file and the database table for different
-    reasons, even though they contain the same data.
+    format (if it is tabular data).
 
 ## Multi-user server environment
 

--- a/docs/design/interface/python-functions.qmd
+++ b/docs/design/interface/python-functions.qmd
@@ -249,7 +249,7 @@ accidental deletion. Outputs `true` if the deletion was successful.
 ::: {.callout-note collapse="true"}
 ### `delete_resource_data(path, confirm)`
 
-Delete all data (Parquet and in the database) and raw data of a specific
+Delete all data (Parquet) and raw data of a specific
 resource. Use `path_resource_raw()` to provide the correct path
 location. The `confirm` argument defaults to `false` so that the user
 needs to explicitly provide `true` to the function argument as
@@ -455,14 +455,6 @@ print(path_properties(6))
 ```
 [PosixPath('~/.sprout/packages/6/datapackage.json')]
 ```
-:::
-
-::: {.callout-note collapse="true"}
-### `path_package_database(package_id)`
-
-Creates the absolute path to the package's database.
-
-<!-- TODO: Not sure if we will keep the database -->
 :::
 
 ::: {.callout-note collapse="true"}

--- a/seedcase_sprout/core/__init__.py
+++ b/seedcase_sprout/core/__init__.py
@@ -24,7 +24,6 @@ from .edit_package_properties import edit_package_properties
 # TODO: Consider having all these in one module.
 from .path_package_functions import (
     path_package,
-    path_package_database,
     path_package_properties,
     path_packages,
 )
@@ -97,7 +96,6 @@ __all__ = [
     # "delete_resource_properties",
     # Path -----
     "path_package",
-    "path_package_database",
     "path_package_properties",
     "path_packages",
     "path_resource",

--- a/seedcase_sprout/core/path_package_functions.py
+++ b/seedcase_sprout/core/path_package_functions.py
@@ -20,19 +20,6 @@ def path_package(package_id: int) -> Path:
     return check_is_package_dir(path)
 
 
-def path_package_database(package_id: int) -> Path:
-    """Gets the absolute path to the specified package's SQL database.
-
-    Args:
-        package_id: The ID of the package.
-
-    Returns:
-        The absolute path to the specified package's database.
-    """
-    path = path_package(package_id) / "database.sql"
-    return check_is_file(path)
-
-
 def path_package_properties(package_id: int) -> Path:
     """Gets the absolute path to the specified package's properties file.
 

--- a/tests/core/directory_structure_setup.py
+++ b/tests/core/directory_structure_setup.py
@@ -17,7 +17,6 @@ def create_test_package_structure(global_path: Path, package_id: int) -> Path:
     path_package = global_path / "packages" / str(package_id)
     path_package.mkdir(parents=True)
     (path_package / "datapackage.json").touch()
-    (path_package / "database.sql").touch()
 
     return path_package
 

--- a/tests/core/test_path_package_functions.py
+++ b/tests/core/test_path_package_functions.py
@@ -4,7 +4,6 @@ from pytest import fixture, mark, raises
 
 from seedcase_sprout.core import (
     path_package,
-    path_package_database,
     path_package_properties,
     path_packages,
 )
@@ -27,7 +26,6 @@ def tmp_sprout_global(monkeypatch, tmp_path):
     "function, expected_path",
     [
         (path_package, "packages/1"),
-        (path_package_database, "packages/1/database.sql"),
         (path_package_properties, "packages/1/datapackage.json"),
     ],
 )
@@ -41,7 +39,7 @@ def test_path_package_functions_return_expected_path(
 
 @mark.parametrize(
     "function",
-    [path_package, path_package_database, path_package_properties],
+    [path_package, path_package_properties],
 )
 def test_path_package_functions_raise_error_if_package_id_does_not_exist(
     tmp_sprout_global, function


### PR DESCRIPTION
## Description

This PR removes `path_package_database()`and removes it from tests. It also removes it from the docs.

Closes #980 

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Added or updated tests
- [X] Updated documentation
- [ ] Ran `just run-all`
