### PR TITLE
refactor: :recycle: `path_package_properties()` -> `path_properties()`

### DIFF
--- a/seedcase_sprout/core/__init__.py
+++ b/seedcase_sprout/core/__init__.py
@@ -23,8 +23,8 @@ from .edit_package_properties import edit_package_properties
 # TODO: Consider having all these in one module.
 from .path_package_functions import (
     path_package,
-    path_package_properties,
     path_packages,
+    path_properties,
 )
 from .path_resource_functions import (
     path_resource,
@@ -94,7 +94,7 @@ __all__ = [
     # "delete_resource_properties",
     # Path -----
     "path_package",
-    "path_package_properties",
+    "path_properties",
     "path_packages",
     "path_resource",
     "path_resource_data",

--- a/seedcase_sprout/core/path_package_functions.py
+++ b/seedcase_sprout/core/path_package_functions.py
@@ -20,7 +20,7 @@ def path_package(package_id: int) -> Path:
     return check_is_package_dir(path)
 
 
-def path_package_properties(package_id: int) -> Path:
+def path_properties(package_id: int) -> Path:
     """Gets the absolute path to the specified package's properties file.
 
     Args:

--- a/tests/core/test_path_package_functions.py
+++ b/tests/core/test_path_package_functions.py
@@ -4,8 +4,8 @@ from pytest import fixture, mark, raises
 
 from seedcase_sprout.core import (
     path_package,
-    path_package_properties,
     path_packages,
+    path_properties,
 )
 from tests.core.directory_structure_setup import (
     create_test_package_structure,
@@ -26,7 +26,7 @@ def tmp_sprout_global(monkeypatch, tmp_path):
     "function, expected_path",
     [
         (path_package, "packages/1"),
-        (path_package_properties, "packages/1/datapackage.json"),
+        (path_properties, "packages/1/datapackage.json"),
     ],
 )
 def test_path_package_functions_return_expected_path(
@@ -39,7 +39,7 @@ def test_path_package_functions_return_expected_path(
 
 @mark.parametrize(
     "function",
-    [path_package, path_package_properties],
+    [path_package, path_properties],
 )
 def test_path_package_functions_raise_error_if_package_id_does_not_exist(
     tmp_sprout_global, function


### PR DESCRIPTION
## Description

We don't have other properties files (like e.g., resource properties files), so we might as well just call it `path_properties`

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Added or updated tests
- [ ] Ran `just run-all`
