### PR TITLE
refactor: :recycle: make schema path resolve when working directory different

### DIFF
--- a/seedcase_sprout/core/checks/config.py
+++ b/seedcase_sprout/core/checks/config.py
@@ -1,7 +1,8 @@
+from importlib.resources import files
 from pathlib import Path
 
-DATA_PACKAGE_SCHEMA_PATH = Path(
-    "seedcase_sprout/core/checks/schemas/data-package-schema.json"
+DATA_PACKAGE_SCHEMA_PATH: Path = files("seedcase_sprout.core.checks.schemas").joinpath(
+    "data-package-schema.json"
 )
 
 NAME_PATTERN = r"^[a-z0-9._-]+$"


### PR DESCRIPTION
## Description

This PR makes it so that the path to the Data Package schema can be resolved even when code is executed from an "unexpected" working directory, e.g. in the guide folder in a Jupyter notebook.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
