### PR TITLE
docs: :pencil2: fix broken link to functions.qmd

### DIFF
--- a/docs/design/interface/index.qmd
+++ b/docs/design/interface/index.qmd
@@ -8,5 +8,5 @@ documents:
 
 -   The main [Outputs](outputs.qmd), including the files, folders, and
     other artifacts that will be produced by Sprout.
--   The [Python functions](python-functions.qmd) that form the core of
+-   The [Python functions](functions.qmd) that form the core of
     Sprout and its extensions.


### PR DESCRIPTION
## Description

The file that is referred to has been renamed.

<!-- Select quick/in-depth as necessary -->
This PR needs no review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
