### PR TITLE
feat: :sparkles: add an `example_package_properties` object

### DIFF
--- a/seedcase_sprout/core/__init__.py
+++ b/seedcase_sprout/core/__init__.py
@@ -10,6 +10,7 @@ from .create_package_structure import create_package_structure
 from .create_resource_properties import create_resource_properties
 from .create_resource_structure import create_resource_structure
 from .edit_package_properties import edit_package_properties
+from .example_package_properties import example_package_properties
 
 # from .delete_resource_raw_file import *
 # from .delete_resource_data import *
@@ -68,6 +69,8 @@ __all__ = [
     "TableDialectProperties",
     "TableSchemaForeignKeyProperties",
     "TableSchemaProperties",
+    # Example properties -----
+    "example_package_properties",
     # Packages -----
     "create_package_structure",
     "edit_package_properties",

--- a/seedcase_sprout/core/example_package_properties.py
+++ b/seedcase_sprout/core/example_package_properties.py
@@ -1,0 +1,25 @@
+from seedcase_sprout.core import (
+    ContributorProperties,
+    LicenseProperties,
+    PackageProperties,
+)
+
+example_package_properties = PackageProperties(
+    name="example-package",
+    title="Example fake data package",
+    description="Data from a fake data package on something.",
+    contributors=[
+        ContributorProperties(
+            title="Jamie Jones",
+            email="jamie_jones@example.com",
+            roles=["creator"],
+        )
+    ],
+    licenses=[
+        LicenseProperties(
+            name="ODC-BY-1.0",
+            path="https://opendatacommons.org/licenses/by",
+            title="Open Data Commons Attribution License 1.0",
+        )
+    ],
+)

--- a/seedcase_sprout/core/example_package_properties.py
+++ b/seedcase_sprout/core/example_package_properties.py
@@ -1,4 +1,4 @@
-from seedcase_sprout.core import (
+from seedcase_sprout.core.properties import (
     ContributorProperties,
     LicenseProperties,
     PackageProperties,


### PR DESCRIPTION
## Description

I'm updating the `create_package_structure()` function and needed this object to make it easier to update the docstrings and example code throughout the package.

Closes #987

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
