### PR TITLE
docs: :building_construction: expand and refine naming scheme

### DIFF
--- a/docs/design/architecture/naming.qmd
+++ b/docs/design/architecture/naming.qmd
@@ -39,20 +39,23 @@ We may also occasionally use "properties" to refer to the file itself.
 |----------------------------|--------------------------------------------|
 | package(s) | A data package that contains a collection of related data resources and properties. |
 | resource(s) | A single data file within a package, along with its properties and associated *raw* data files. |
-| properties or property | Metadata about a package or resource. |
-| file structure or structure | The file and folder structure of a package. |
+| properties | Metadata about a package or resource. |
 | path | A file path listing the location of folders or files that Sprout interacts with. |
 | data | The data file within a resource. Within Sprout, this includes the Parquet file and raw files. |
-| identifier | A unique identifier for a package or resource, denoted as `id`. |
+| identifier | A unique identifier for a package (*only for server environments*) or resource, denoted as `id`. |
+| changes | The changes made to the data package that will be stored in the version control repository of the data package. |
+| version | The version of the data package, denoted as `version`. |
+| observational unit | The unit of observation, meaning the data associated with a specific entity at a specific time, e.g. a person who had their weight measured on their 30th birthday. |
 
 : General objects used throughout Sprout.
 
 | File or folder | Description |
 |----------------------------|--------------------------------------------|
-| packages | The folder that contains all packages. |
+| dirs | A shortened name for folder or directory. |
+| packages | The folder that contains all packages. *Only for server environments*. |
 | resources | The folder that contains all resource files in a package. |
 | raw | The folder that contains raw data files for a data resource. |
-| raw data file | A compressed raw data file format, such as a `.zip`, `.gzip`, or `.tar.gz` file. |
+| raw data file | A compressed raw data file format, such as a `.gzip` file. |
 | JSON | The main way we save and pass information around on the package's or resource's properties. |
 | Parquet | A columnar, efficient storage file format that we use to save data within a resource. |
 
@@ -62,14 +65,13 @@ We may also occasionally use "properties" to refer to the file itself.
 
 | Action | Description |
 |----------------------------|--------------------------------------------|
-| create | Create a new object. |
-| build | Build implies either creating a new object or recreating an existing one, e.g. (re-)build a file like the README or Parquet file. |
-| list | List basic details about many objects. |
-| edit | Edit an object, specifically the properties object. |
-| add | Add another object to an existing object, specifically adding data to a resource. |
+| commit | Saves changes made in a data package to the version control system. |
+| create | Creates a new object or sets up a new object and writes it to the file system. |
+| build | Build means generating or re-generating an object from other objects, e.g. (re-)build the text for the README. |
+| update | Update an object, mainly of the properties or version objects. |
 | write | Write an object to a file. |
-| copy | Copy a file from one location to another. |
-| delete | Permanently delete an object. |
+| read | Reads an object from a file. |
+| delete | Permanently delete a file(s) associated with an object (e.g. delete a whole package or observational unit). |
 | extract | Extract specific information from an object, specifically the properties from a data file. |
 
 : General actions that Sprout can take on objects or files/folders.


### PR DESCRIPTION
## Description

I've been thinking a bit more about the naming scheme. As we've developed more and used it and added the guide, some things feel a bit rough/has tension. Especially with how we've named things. Comments about each change is added to the PR.

Closes #1059

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.
