### PR TITLE
docs: :memo: callout note about diagrams not rendering on Firefox

### DIFF
--- a/docs/design/architecture/c4-models.qmd
+++ b/docs/design/architecture/c4-models.qmd
@@ -22,6 +22,11 @@ The Context diagram shows the users and any external systems that
 interact with Sprout. This includes the user roles described in the
 [User Personas](user-personas.qmd) page.
 
+::: callout-caution
+For some reason, these diagrams don't display well on some browsers like
+Firefox. To see them, try using a different browser like Chrome or Edge.
+:::
+
 ::: column-page
 ```{mermaid}
 %%| fig-cap: "C4 Context diagram showing a very basic overview of Sprout and its anticipated users."

--- a/docs/design/interface/functions.qmd
+++ b/docs/design/interface/functions.qmd
@@ -64,6 +64,11 @@ Functions shown with a {{< var wip >}} icon are not yet implemented
 while those with a {{< var done >}} icon are implemented.
 :::
 
+::: callout-caution
+For some reason, the diagrams below don't display well on some browsers like
+Firefox. To see them, try using a different browser like Chrome or Edge.
+:::
+
 ## Data package functions
 
 ### {{< var wip >}} `create_package_properties(properties, path)`


### PR DESCRIPTION
## Description

This PR adds a small note to let readers know the diagrams don't show on Firefox.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.
