### PR TITLE
docs: :building_construction: rename to `_dirs` rather than `_structure`

### DIFF
--- a/docs/design/interface/functions.qmd
+++ b/docs/design/interface/functions.qmd
@@ -101,10 +101,19 @@ more details.
 
 ## Data resource functions
 
-### {{< var done >}} `create_resource_structure(path)`
+### {{< var done >}} `create_resource_dirs(path)`
 
-See the help documentation with `help(create_resource_structure)` for
+See the help documentation with `help(create_resource_dirs)` for
 more details.
+
+```{mermaid}
+flowchart
+    in_path[/path/]
+    function("create_resource_dirs()")
+    out[("{path}/resources/{id}/<br>{path}/resources/{id}/raw/")]
+    in_path --> function
+    function --> out
+```
 
 ### {{< var done >}} `create_resource_properties(path, properties)`
 


### PR DESCRIPTION
## Description

Since removing `create_package_structure()`, it makes more sense to rename this function to simply `create_resource_dirs()`, since that's all it is doing.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.