### PR TITLE
chore: :fire: remove "geojson", "topojson", and "ods" from `SUPPORTED_FORMATS`

### DIFF
--- a/src/seedcase_sprout/core/check_is_supported_format.py
+++ b/src/seedcase_sprout/core/check_is_supported_format.py
@@ -8,9 +8,6 @@ SUPPORTED_FORMATS = [
     "json",
     "jsonl",
     "ndjson",
-    "geojson",
-    "topojson",
-    "ods",
     "parq",
     "parquet",
 ]


### PR DESCRIPTION
## Description

To reflect the file formats we currently support property extraction from.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
