### PR TITLE
feat: :sparkles: add mapping from Frictionless data types to Polars data types

### DIFF
--- a/src/seedcase_sprout/core/map_data_types.py
+++ b/src/seedcase_sprout/core/map_data_types.py
@@ -1,0 +1,24 @@
+import polars as pl
+
+from seedcase_sprout.core.properties import FieldType
+
+# Mapping from Frictionless data types to Polars data types.
+# See https://sprout.seedcase-project.org/docs/design/interface/data-types
+# for more information.
+FRICTIONLESS_TO_POLARS: dict[FieldType, pl.DataType] = {
+    "string": pl.String,
+    "boolean": pl.Boolean,
+    "integer": pl.Int64,
+    "number": pl.Float64,
+    "year": pl.Int32,
+    "datetime": pl.Datetime,
+    "date": pl.Date,
+    "time": pl.Time,
+    "yearmonth": pl.Date,
+    "geopoint": pl.Array(pl.Float64, 2),
+    "duration": pl.String,
+    "object": pl.String,
+    "array": pl.String,
+    "geojson": pl.String,
+    "any": pl.String,
+}


### PR DESCRIPTION
## Description

This PR adds the mapping from Frictionless data types to Polars data types described in https://github.com/seedcase-project/seedcase-sprout/pull/1098.

I'm adding this now because I'm using it in the checks and presumably Signe will use it when writing to Parquet.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
