### PR TITLE
fix: :bug: only remove qmd files in reference post render to fix md formatting issues

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,7 +1,7 @@
 project:
   type: seedcase-theme
   pre-render: rm -rf .storage
-  post-render: rm -rf docs/reference
+  post-render: rm -rf docs/reference/*.qmd
   render:
     - "docs/*"
     - "index.qmd"


### PR DESCRIPTION
## Description

Removing the entire `reference/` folder post-render is problematic because the `_sidebar.yml` file in this folder is referenced under `metadata-files` in `_quarto.yml`. When this file is removed post-render, it seems to disrupt Quarto's functionality in VS Code, affecting its visual mode. As a result, formatting (including column wrapping at length 72) doesn't work as expected. 

Changing the post-render process to remove only `qmd` files resolves this issue, since (as far as I understand) preserving `_sidebar.yml` ensures that `_quarto.yml` remains valid and maintains an uninterrupted visual mode.

Please check if this works for you locally by: 

1. Go to this branch 
2. Run `just build-website` (to get the `_sidebar.yml` back) 
3. In an `md` or a `qmd` file, go to visual mode, save it, and go back to source mode.

Is the formatting still OK after these steps for you as well? 🤞 

Closes #1089 

<!-- Select quick/in-depth as necessary —>
This PR needs an in-depth review.

## Checklist

- [X] Ran `just run-all`
