### PR TITLE
feat: :sparkles: make `build_readme_text()` and `write_file()` public

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -87,6 +87,7 @@ quartodoc:
       contents:
         - create_package_properties
         - edit_package_properties
+        - build_readme_text
 
     - subtitle: "Data resource functions"
       desc: "Functions to work with and manage data resources found within a data package."
@@ -131,6 +132,7 @@ quartodoc:
       package: "seedcase_sprout.core"
       contents:
         - example_package_properties
+        - write_file
 
 metadata-files:
   - docs/reference/_sidebar.yml

--- a/src/seedcase_sprout/core/__init__.py
+++ b/src/seedcase_sprout/core/__init__.py
@@ -5,16 +5,17 @@
 # Packages -----
 # from .delete_package import *
 # Resources -----
+# from .delete_resource_raw_file import *
+# from .delete_resource_data import *
+# from .delete_resource_properties import *
+
+from .build_readme_text import build_readme_text
 from .create_package_properties import create_package_properties
 from .create_resource_properties import create_resource_properties
 from .create_resource_structure import create_resource_structure
 from .edit_package_properties import edit_package_properties
 from .example_package_properties import example_package_properties
 
-# from .delete_resource_raw_file import *
-# from .delete_resource_data import *
-# from .delete_resource_properties import *
-# Path -----
 # TODO: Consider having all these in one module.
 from .path_package_functions import (
     path_package,
@@ -46,6 +47,7 @@ from .properties import (
 from .sprout_checks.check_package_properties import check_package_properties
 from .sprout_checks.check_properties import check_properties
 from .sprout_checks.check_resource_properties import check_resource_properties
+from .write_file import write_file
 from .write_package_properties import write_package_properties
 
 # from .extract_resource_properties import *
@@ -76,6 +78,7 @@ __all__ = [
     "create_package_properties",
     "edit_package_properties",
     "write_package_properties",
+    "build_readme_text",
     # "delete_package",
     # Resources -----
     "create_resource_structure",
@@ -101,6 +104,7 @@ __all__ = [
     "path_sprout_global",
     # Helpers -----
     # "pretty_json",
+    "write_file",
     # Checks -----
     "check_package_properties",
     "check_properties",

--- a/src/seedcase_sprout/core/build_readme_text.py
+++ b/src/seedcase_sprout/core/build_readme_text.py
@@ -15,11 +15,15 @@ TEMPLATES_PATH: Path = files("seedcase_sprout.core").joinpath("templates")
 def build_readme_text(properties: PackageProperties) -> str:
     """Creates a string containing the README text.
 
+    Using a template, this will build a README file with the contents of the
+    properties object in a human-readable format. Use `write_file()` to save
+    the text to the `README.md` file.
+
     Args:
-      properties: An object containing the package and resource properties.
+        properties: An object containing the package and resource properties.
 
     Returns:
-      A string with the README text based on the properties.
+        A string with the README text based on the properties.
     """
     env = Environment(loader=FileSystemLoader(TEMPLATES_PATH))
     env.filters["join_names"] = join_names


### PR DESCRIPTION
## Description

Seems we forgot to export these to be public functions.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
