### PR TITLE
docs: :building_construction: include path arg of path functions in interface doc

### DIFF
--- a/docs/design/interface/functions.qmd
+++ b/docs/design/interface/functions.qmd
@@ -277,6 +277,8 @@ flowchart
 ## Path functions
 
 -   All of these functions output a path object.
+-   All of these functions have an optional `path` argument that defaults to
+    the current working directory.
 -   The paths returned by all of these functions are paths that exist,
     so all include a `check_is_dir()` or `check_is_file()` check.
 -   If the wrong `resource_id` is given, an error message will include a
@@ -287,25 +289,25 @@ flowchart
 See the help documentation with `help(path_properties)` for more
 details.
 
-### {{< var done >}} `path_resources()`
+### {{< var done >}} `path_resources(path)`
 
 See the help documentation with `help(path_resources)` for more details.
 
-### {{< var done >}} `path_resource(resource_id)`
+### {{< var done >}} `path_resource(resource_id, path)`
 
 See the help documentation with `help(path_resource)` for more details.
 
-### {{< var done >}} `path_resource_raw(resource_id)`
+### {{< var done >}} `path_resource_raw(resource_id, path)`
 
 See the help documentation with `help(path_resource_raw)` for more
 details.
 
-### {{< var done >}} `path_resource_raw_files(package_id, resource_id)`
+### {{< var done >}} `path_resource_raw_files(resource_id, path)`
 
 See the help documentation with `help(path_resource_raw_files)` for more
 details.
 
-### {{< var done >}} `path_resource_data(package_id, resource_id)`
+### {{< var done >}} `path_resource_data(resource_id, path)`
 
 See the help documentation with `help(path_resource_data)` for more
 details.


### PR DESCRIPTION
## Description

Add and describe the path argument to the `path_` functions.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
