### PR TITLE
feat: :sparkles: check data types in whole data frame

### DIFF
--- a/src/seedcase_sprout/core/sprout_checks/check_data_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_types.py
@@ -23,7 +23,7 @@ def check_data_types(data_frame: pl.DataFrame, resource_properties: ResourceProp
 
     Each value in each data frame column is checked against the data type given in the
     resource properties for the corresponding field. This function expects the column
-    names of the data frame to be correct and assumes that missing values are
+    names of the data frame to be the same as in the `resource_properties` and assumes that missing values are
     represented by null.
 
     Args:
@@ -34,8 +34,8 @@ def check_data_types(data_frame: pl.DataFrame, resource_properties: ResourceProp
         The data frame, if all data type checks passed.
 
     Raises:
-        ExceptionGroup[ValueError]: One error for each column/field where any values
-            failed the data type check. Each error lists all failed values together
+        ExceptionGroup[ValueError]: One error for each column/field that has any values
+            that failed the data type check. Each error lists all failed values together
             with their row index.
     """
     fields: list[FieldProperties] = get_nested_attr(

--- a/src/seedcase_sprout/core/sprout_checks/check_data_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_types.py
@@ -15,7 +15,7 @@ from seedcase_sprout.core.sprout_checks.get_field_error_message import (
 # Column name for column containing the row index
 INDEX_COLUMN = "__row_index__"
 # Column name for column containing the result of the check
-CHECK_COLUMN_NAME = "{column}_correct"
+CHECK_COLUMN_NAME = "__{column}_check_data_types_correct__"
 
 
 def check_data_types(data_frame: pl.DataFrame, resource_properties: ResourceProperties):

--- a/src/seedcase_sprout/core/sprout_checks/check_data_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_types.py
@@ -1,0 +1,149 @@
+import polars as pl
+
+from seedcase_sprout.core.get_nested_attr import get_nested_attr
+from seedcase_sprout.core.properties import (
+    FieldProperties,
+    ResourceProperties,
+)
+from seedcase_sprout.core.sprout_checks.check_column_data_types import (
+    check_is_boolean,
+    check_is_castable_type,
+    check_is_date,
+    check_is_datetime,
+    check_is_geopoint,
+    check_is_json,
+    check_is_time,
+    check_is_yearmonth,
+)
+from seedcase_sprout.core.sprout_checks.get_field_error_message import (
+    get_field_error_message,
+)
+
+# Column name for column containing the row index
+INDEX_COLUMN = "__row_index__"
+# Column name for column containing the result of the check
+CHECK_COLUMN_NAME = "{column}_error"
+
+
+def check_data_types(data_frame: pl.DataFrame, resource_properties: ResourceProperties):
+    """Checks that all data items match their data type given in `resource_properties`.
+
+    Each value in each data frame column is checked against the data type given in the
+    resource properties for the corresponding field. This function expects the column
+    names of the data frame to be correct and assumes that missing values are
+    represented by null.
+
+    Args:
+        data_frame: The data frame to check.
+        resource_properties: The resource properties to check against.
+
+    Returns:
+        The data frame, if all data type checks passed.
+
+    Raises:
+        ExceptionGroup[ValueError]: One error for each column/field where any values
+            failed the data type check. Each error lists all failed values together
+            with their row index.
+    """
+    fields: list[FieldProperties] = get_nested_attr(
+        resource_properties, "schema.fields", default=[]
+    )
+
+    # Add column with failed values for each field
+    df_checked = data_frame.with_row_index(INDEX_COLUMN).with_columns(
+        check_column(data_frame, field)
+        .pipe(extract_failed_values, field.name)
+        .alias(CHECK_COLUMN_NAME.format(column=field.name))
+        for field in fields
+    )
+
+    # Collect failed values into one error per field
+    errors = []
+    for field in fields:
+        failed_values = (
+            df_checked.get_column(CHECK_COLUMN_NAME.format(column=field.name))
+            .drop_nulls()
+            .to_list()
+        )
+        if failed_values:
+            errors.append(ValueError(get_field_error_message(field, failed_values)))
+
+    if errors:
+        raise ExceptionGroup(
+            "Some columns contain values that do not match the column's data type.",
+            errors,
+        )
+
+    return data_frame
+
+
+def extract_failed_values(this_column: pl.Expr, field_name: str) -> pl.Expr:
+    """Adds a short error message for each value that failed the data type check.
+
+    The error message includes the index of the row and the incorrect value itself.
+
+    Args:
+        this_column: The column being operated on.
+        field_name: The name of the field to check.
+
+    Returns:
+        A Polars expression.
+    """
+    return (
+        pl.when(this_column.is_null())
+        .then(
+            pl.format(
+                "[{}]: '{}'",
+                pl.col(INDEX_COLUMN),
+                pl.col(field_name),
+            )
+        )
+        .otherwise(pl.lit(None))
+    )
+
+
+def check_column(data_frame: pl.DataFrame, field: FieldProperties) -> pl.Expr:
+    """Checks that the values in the given column/field are of the correct type.
+
+    This function selects and returns the appropriate check expression for the field
+    based on the field's type.
+
+    Args:
+        data_frame: The data frame being operated on.
+        field: The field to check.
+
+    Returns:
+        A Polars expression for checking the data type of values in the column.
+    """
+    field_name, field_type = field.name, field.type
+    match field_type:
+        case "boolean":
+            return check_is_boolean(field_name)
+
+        case "integer" | "number" | "year":
+            return check_is_castable_type(field_name, field.type)
+
+        case "yearmonth":
+            return check_is_yearmonth(field_name)
+
+        case "datetime":
+            return check_is_datetime(data_frame, field_name)
+
+        case "date":
+            return check_is_date(field_name)
+
+        case "time":
+            return check_is_time(field_name)
+
+        case "geopoint":
+            return check_is_geopoint(field_name)
+
+        case "array":
+            return check_is_json(field_name, list)
+
+        case "object" | "geojson":
+            return check_is_json(field_name, dict)
+
+        # Catches: string, any, duration
+        case _:
+            return pl.col(field_name)

--- a/src/seedcase_sprout/core/sprout_checks/check_data_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_types.py
@@ -59,7 +59,7 @@ def check_data_types(data_frame: pl.DataFrame, resource_properties: ResourceProp
             .to_list()
         )
         if failed_values:
-            errors.append(ValueError(get_field_error_message(field, failed_values)))
+            errors.append(TypeError(get_field_error_message(field, failed_values)))
 
     if errors:
         raise ExceptionGroup(

--- a/src/seedcase_sprout/core/sprout_checks/check_data_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_types.py
@@ -23,8 +23,8 @@ def check_data_types(data_frame: pl.DataFrame, resource_properties: ResourceProp
 
     Each value in each data frame column is checked against the data type given in the
     resource properties for the corresponding field. This function expects the column
-    names of the data frame to be the same as in the `resource_properties` and assumes that missing values are
-    represented by null.
+    names of the data frame to be the same as in the `resource_properties` and assumes
+    that missing values are represented by null.
 
     Args:
         data_frame: The data frame to check.

--- a/src/seedcase_sprout/core/sprout_checks/check_data_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_types.py
@@ -108,7 +108,7 @@ def check_column(data_frame: pl.DataFrame, field: FieldProperties) -> pl.Expr:
     Returns:
         A Polars expression for checking the data type of values in the column.
     """
-    field_name, field_type = field.name, field.type
+    field_name, field_type = field.name, (field.type or "any")
     check = FRICTIONLESS_TO_COLUMN_CHECK[field_type]
     return (
         pl.col(field_name)

--- a/src/seedcase_sprout/core/sprout_checks/field_general_error_messages.py
+++ b/src/seedcase_sprout/core/sprout_checks/field_general_error_messages.py
@@ -1,4 +1,4 @@
-from seedcase_sprout.core.properties import FieldProperties, FieldType
+from seedcase_sprout.core.properties import FieldType
 from seedcase_sprout.core.sprout_checks.check_column_data_types import BOOLEAN_VALUES
 
 DATA_TYPES_URL = "https://sprout.seedcase-project.org/docs/design/interface/data-types#"
@@ -45,24 +45,3 @@ FIELD_GENERAL_ERROR_MESSAGES: dict[FieldType, str] = {
     "array": "The given value doesn't seem to be a correctly formatted JSON array.",
     "geojson": "The given value doesn't seem to be a correctly formatted JSON object.",
 }
-
-
-def get_field_error_message(field: FieldProperties, failed_values: list[str]) -> str:
-    """Returns an error message for the given field.
-
-    The error message includes a general comment about the data type of the field,
-    the name of the field, and a list of failed values in the field's column together
-    with their row indices.
-
-    Args:
-        field: The field to get the error message for.
-        failed_values: The failed values in the field's column.
-
-    Returns:
-        An error message for the field.
-    """
-    return (
-        f"{FIELD_GENERAL_ERROR_MESSAGES.get(field.type, '')} "
-        f"Values in column '{field.name}' at the following row indices "
-        f"could not be parsed as '{field.type}': {', '.join(failed_values)}"
-    )

--- a/src/seedcase_sprout/core/sprout_checks/get_field_error_message.py
+++ b/src/seedcase_sprout/core/sprout_checks/get_field_error_message.py
@@ -1,0 +1,68 @@
+from seedcase_sprout.core.properties import FieldProperties, FieldType
+from seedcase_sprout.core.sprout_checks.check_column_data_types import BOOLEAN_VALUES
+
+DATA_TYPES_URL = "https://sprout.seedcase-project.org/docs/design/interface/data-types#"
+
+FIELD_GENERAL_ERROR_MESSAGES: dict[FieldType, str] = {
+    "boolean": f"The given value needs to be one of {BOOLEAN_VALUES}.",
+    "year": (
+        "The given value doesn't seem to be a correctly formatted year value. "
+        "The expected format for year values is YYYY. See "
+        f"{DATA_TYPES_URL}year for more information."
+    ),
+    "datetime": (
+        "The given value doesn't seem to be a correctly formatted datetime value. "
+        "The expected format for datetime values is YYYY-MM-DDTHH:MM:SS with optional "
+        f"milliseconds and time zone information. See {DATA_TYPES_URL}datetime "
+        "for more information."
+    ),
+    "date": (
+        "The given value doesn't seem to be a correctly formatted date value. "
+        "The expected format for date values is YYYY-MM-DD. See "
+        f"{DATA_TYPES_URL}date for more information."
+    ),
+    "time": (
+        "The given value doesn't seem to be a correctly formatted time value. "
+        "The expected format for time values is HH:MM:SS. See "
+        f"{DATA_TYPES_URL}time for more information."
+    ),
+    "yearmonth": (
+        "The given value doesn't seem to be a correctly formatted yearmonth value. "
+        "The expected format for yearmonth values is YYYY-MM. See "
+        f"{DATA_TYPES_URL}yearmonth for more information."
+    ),
+    "geopoint": (
+        "The given value doesn't seem to be a correctly formatted geographical point. "
+        "The expected format for geographical points is LAT, LONG. See "
+        f"{DATA_TYPES_URL}geopoint for more information."
+    ),
+    "duration": (
+        "The given value doesn't seem to be a correctly formatted duration value. "
+        "The expected format for duration values is PnYnMnDTnHnMnS. See "
+        f"{DATA_TYPES_URL}duration for more information."
+    ),
+    "object": "The given value doesn't seem to be a correctly formatted JSON object.",
+    "array": "The given value doesn't seem to be a correctly formatted JSON array.",
+    "geojson": "The given value doesn't seem to be a correctly formatted JSON object.",
+}
+
+
+def get_field_error_message(field: FieldProperties, failed_values: list[str]) -> str:
+    """Returns an error message for the given field.
+
+    The error message includes a general comment about the data type of the field,
+    the name of the field, and a list of failed values in the field's column together
+    with their row indices.
+
+    Args:
+        field: The field to get the error message for.
+        failed_values: The failed values in the field's column.
+
+    Returns:
+        An error message for the field.
+    """
+    return (
+        f"{FIELD_GENERAL_ERROR_MESSAGES.get(field.type, '')} "
+        f"Values in column '{field.name}' at the following row indices "
+        f"could not be parsed as '{field.type}': {', '.join(failed_values)}"
+    )

--- a/tests/core/sprout_checks/test_check_data_types.py
+++ b/tests/core/sprout_checks/test_check_data_types.py
@@ -152,10 +152,12 @@ def test_error_raised_when_data_types_do_not_match_properties(data):
 
     # Each column should have the incorrect values listed in the corresponding error
     for col_name, column in bad_data.items():
-        error_message = next(str(err) for err in errors if f"'{col_name}'" in str(err))
+        error_message = next(
+            str(error) for error in errors if f"'{col_name}'" in str(error)
+        )
         # Find all incorrect values, e.g. [11]: 'not a date'
         flagged_values = re.findall(r"\[(\d+)\]: '([^']*)'", error_message)
         expected_flagged_values = [
-            (str(r), str(bad_value)) for r, bad_value in zip(bad_rows, column[:3])
+            (str(row), str(value)) for row, value in zip(bad_rows, column[:3])
         ]
         assert flagged_values == expected_flagged_values

--- a/tests/core/sprout_checks/test_check_data_types.py
+++ b/tests/core/sprout_checks/test_check_data_types.py
@@ -50,6 +50,7 @@ resource_properties = ResourceProperties(
             FieldProperties(name="my_date", type="date"),
             FieldProperties(name="my_datetime_tz", type="datetime"),
             FieldProperties(name="my_datetime_no_tz", type="datetime"),
+            FieldProperties(name="my_datetime_null_start", type="datetime"),
             FieldProperties(name="my_time", type="time"),
             FieldProperties(name="my_year", type="year"),
             FieldProperties(name="my_integer", type="integer"),
@@ -76,6 +77,7 @@ bad_data = {
     "my_geojson": OBJECT_BAD_VALUES,
     "my_datetime_tz": DATETIME_BAD_VALUES_WHEN_TIMEZONE,
     "my_datetime_no_tz": DATETIME_BAD_VALUES_WHEN_NO_TIMEZONE,
+    "my_datetime_null_start": DATETIME_BAD_VALUES_WHEN_NO_TIMEZONE,
 }
 
 
@@ -89,6 +91,7 @@ def data():
         "my_yearmonth": YEARMONTH_GOOD_VALUES,
         "my_datetime_tz": DATETIME_GOOD_VALUES_WHEN_TIMEZONE,
         "my_datetime_no_tz": DATETIME_GOOD_VALUES_WHEN_NO_TIMEZONE,
+        "my_datetime_null_start": [None] + DATETIME_GOOD_VALUES_WHEN_NO_TIMEZONE,
         "my_date": DATE_GOOD_VALUES,
         "my_time": TIME_GOOD_VALUES,
         "my_geopoint": GEOPOINT_GOOD_VALUES,

--- a/tests/core/sprout_checks/test_check_data_types.py
+++ b/tests/core/sprout_checks/test_check_data_types.py
@@ -1,0 +1,153 @@
+import re
+from pathlib import Path
+
+import polars as pl
+from pytest import fixture, raises
+
+from seedcase_sprout.core.properties import (
+    FieldProperties,
+    ResourceProperties,
+    TableSchemaProperties,
+)
+from seedcase_sprout.core.sprout_checks.check_data_types import check_data_types
+from tests.core.sprout_checks.test_check_column_data_types import (
+    ARRAY_BAD_VALUES,
+    ARRAY_GOOD_VALUES,
+    BOOLEAN_BAD_VALUES,
+    BOOLEAN_GOOD_VALUES,
+    DATE_BAD_VALUES,
+    DATE_GOOD_VALUES,
+    DATETIME_BAD_VALUES_WHEN_NO_TIMEZONE,
+    DATETIME_BAD_VALUES_WHEN_TIMEZONE,
+    DATETIME_GOOD_VALUES_WHEN_NO_TIMEZONE,
+    DATETIME_GOOD_VALUES_WHEN_TIMEZONE,
+    GEOPOINT_BAD_VALUES,
+    GEOPOINT_GOOD_VALUES,
+    INTEGER_BAD_VALUES,
+    INTEGER_GOOD_VALUES,
+    NUMBER_BAD_VALUES,
+    NUMBER_GOOD_VALUES,
+    OBJECT_BAD_VALUES,
+    OBJECT_GOOD_VALUES,
+    TIME_BAD_VALUES,
+    TIME_GOOD_VALUES,
+    YEARMONTH_BAD_VALUES,
+    YEARMONTH_GOOD_VALUES,
+)
+
+resource_properties = ResourceProperties(
+    name="data",
+    title="data",
+    path=str(Path("resources", "1", "data.csv")),
+    description="My data...",
+    schema=TableSchemaProperties(
+        fields=[
+            FieldProperties(name="my_string", type="string"),
+            FieldProperties(name="my_any", type="any"),
+            FieldProperties(name="my_duration", type="duration"),
+            FieldProperties(name="my_boolean", type="boolean"),
+            FieldProperties(name="my_yearmonth", type="yearmonth"),
+            FieldProperties(name="my_date", type="date"),
+            FieldProperties(name="my_datetime_tz", type="datetime"),
+            FieldProperties(name="my_datetime_no_tz", type="datetime"),
+            FieldProperties(name="my_time", type="time"),
+            FieldProperties(name="my_year", type="year"),
+            FieldProperties(name="my_integer", type="integer"),
+            FieldProperties(name="my_number", type="number"),
+            FieldProperties(name="my_geopoint", type="geopoint"),
+            FieldProperties(name="my_array", type="array"),
+            FieldProperties(name="my_object", type="object"),
+            FieldProperties(name="my_geojson", type="geojson"),
+        ]
+    ),
+)
+
+bad_data = {
+    "my_boolean": BOOLEAN_BAD_VALUES,
+    "my_yearmonth": YEARMONTH_BAD_VALUES,
+    "my_date": DATE_BAD_VALUES,
+    "my_time": TIME_BAD_VALUES,
+    "my_integer": INTEGER_BAD_VALUES,
+    "my_year": INTEGER_BAD_VALUES,
+    "my_number": NUMBER_BAD_VALUES,
+    "my_geopoint": GEOPOINT_BAD_VALUES,
+    "my_array": ARRAY_BAD_VALUES,
+    "my_object": OBJECT_BAD_VALUES,
+    "my_geojson": OBJECT_BAD_VALUES,
+    "my_datetime_tz": DATETIME_BAD_VALUES_WHEN_TIMEZONE,
+    "my_datetime_no_tz": DATETIME_BAD_VALUES_WHEN_NO_TIMEZONE,
+}
+
+
+@fixture
+def data():
+    data = {
+        "my_boolean": BOOLEAN_GOOD_VALUES,
+        "my_integer": INTEGER_GOOD_VALUES,
+        "my_number": NUMBER_GOOD_VALUES,
+        "my_year": INTEGER_GOOD_VALUES,
+        "my_yearmonth": YEARMONTH_GOOD_VALUES,
+        "my_datetime_tz": DATETIME_GOOD_VALUES_WHEN_TIMEZONE,
+        "my_datetime_no_tz": DATETIME_GOOD_VALUES_WHEN_NO_TIMEZONE,
+        "my_date": DATE_GOOD_VALUES,
+        "my_time": TIME_GOOD_VALUES,
+        "my_geopoint": GEOPOINT_GOOD_VALUES,
+        "my_array": ARRAY_GOOD_VALUES,
+        "my_object": OBJECT_GOOD_VALUES,
+        "my_geojson": OBJECT_GOOD_VALUES,
+        "my_string": ["some text"],
+        "my_duration": ["P1Y2M3DT10H30M45.343S"],
+        "my_any": ["some text", 99, "[]", "2030-12-12", True],
+    }
+
+    # Make all columns have the same number of rows
+    # Add at least one null in each column
+    max_rows = max(len(column) for column in data.values())
+    return {
+        col_name: column + [None] * (max_rows - len(column) + 1)
+        for col_name, column in data.items()
+    }
+
+
+def test_no_error_raised_when_properties_empty(data):
+    """Should raise no errors when the properties are empty."""
+    df = pl.DataFrame(data, strict=False)
+
+    assert check_data_types(df, ResourceProperties()) is df
+
+
+def test_no_error_raised_when_data_types_match_properties(data):
+    """When the data frame only contains correct data, no error is raised."""
+    df = pl.DataFrame(data, strict=False)
+
+    assert check_data_types(df, resource_properties) is df
+
+
+def test_error_raised_when_data_types_do_not_match_properties(data):
+    """When the data frame contains incorrect data, an error is raised for each column
+    with incorrect values. Each error's error message lists the row indices of the
+    incorrect values and the incorrect values themselves."""
+    # Replace last 3 good values with bad values in each (non-string) column
+    for col_name, column in data.items():
+        if col_name in bad_data:
+            column[-3:] = bad_data[col_name][:3]
+    bad_rows = range(len(next(iter(data.values()))))[-3:]
+    df = pl.DataFrame(data, strict=False)
+
+    with raises(ExceptionGroup) as error_info:
+        check_data_types(df, resource_properties)
+
+    errors = error_info.value.exceptions
+
+    # One error for each column with incorrect values
+    assert len(errors) == len(bad_data)
+
+    # Each column should have the incorrect values listed in the corresponding error
+    for col_name, column in bad_data.items():
+        error_message = next(str(err) for err in errors if f"'{col_name}'" in str(err))
+        # Find all incorrect values, e.g. [11]: 'not a date'
+        flagged_values = re.findall(r"\[(\d+)\]: '([^']*)'", error_message)
+        expected_flagged_values = [
+            (str(r), str(bad_value)) for r, bad_value in zip(bad_rows, column[:3])
+        ]
+        assert flagged_values == expected_flagged_values

--- a/tests/core/sprout_checks/test_check_data_types.py
+++ b/tests/core/sprout_checks/test_check_data_types.py
@@ -11,6 +11,7 @@ from seedcase_sprout.core.properties import (
 )
 from seedcase_sprout.core.sprout_checks.check_data_types import check_data_types
 from tests.core.sprout_checks.test_check_column_data_types import (
+    ANY_VALUES,
     ARRAY_BAD_VALUES,
     ARRAY_GOOD_VALUES,
     BOOLEAN_BAD_VALUES,
@@ -21,6 +22,7 @@ from tests.core.sprout_checks.test_check_column_data_types import (
     DATETIME_BAD_VALUES_WHEN_TIMEZONE,
     DATETIME_GOOD_VALUES_WHEN_NO_TIMEZONE,
     DATETIME_GOOD_VALUES_WHEN_TIMEZONE,
+    DURATION_VALUES,
     GEOPOINT_BAD_VALUES,
     GEOPOINT_GOOD_VALUES,
     INTEGER_BAD_VALUES,
@@ -29,6 +31,7 @@ from tests.core.sprout_checks.test_check_column_data_types import (
     NUMBER_GOOD_VALUES,
     OBJECT_BAD_VALUES,
     OBJECT_GOOD_VALUES,
+    STRING_VALUES,
     TIME_BAD_VALUES,
     TIME_GOOD_VALUES,
     YEARMONTH_BAD_VALUES,
@@ -98,9 +101,9 @@ def data():
         "my_array": ARRAY_GOOD_VALUES,
         "my_object": OBJECT_GOOD_VALUES,
         "my_geojson": OBJECT_GOOD_VALUES,
-        "my_string": ["some text"],
-        "my_duration": ["P1Y2M3DT10H30M45.343S"],
-        "my_any": ["some text", 99, "[]", "2030-12-12", True],
+        "my_string": STRING_VALUES,
+        "my_duration": DURATION_VALUES,
+        "my_any": ANY_VALUES,
     }
 
     # Make all columns have the same number of rows

--- a/tests/core/sprout_checks/test_check_data_types.py
+++ b/tests/core/sprout_checks/test_check_data_types.py
@@ -47,6 +47,7 @@ resource_properties = ResourceProperties(
         fields=[
             FieldProperties(name="my_string", type="string"),
             FieldProperties(name="my_any", type="any"),
+            FieldProperties(name="my_none", type=None),
             FieldProperties(name="my_duration", type="duration"),
             FieldProperties(name="my_boolean", type="boolean"),
             FieldProperties(name="my_yearmonth", type="yearmonth"),
@@ -104,6 +105,7 @@ def data():
         "my_string": STRING_VALUES,
         "my_duration": DURATION_VALUES,
         "my_any": ANY_VALUES,
+        "my_none": ANY_VALUES,
     }
 
     # Make all columns have the same number of rows

--- a/tests/core/sprout_checks/test_check_data_types.py
+++ b/tests/core/sprout_checks/test_check_data_types.py
@@ -160,4 +160,5 @@ def test_error_raised_when_data_types_do_not_match_properties(data):
         expected_flagged_values = [
             (str(row), str(value)) for row, value in zip(bad_rows, column[:3])
         ]
+        assert f"column '{col_name}'" in error_message
         assert flagged_values == expected_flagged_values


### PR DESCRIPTION
## Description
Stacked PR [2/2]

This PR uses the checks defined in #1111 to check all columns in a data frame. All errors are collected before a summary error is thrown.

Closes #1032 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
