### PR TITLE
docs: :memo: add supported formats doc to design interface

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -57,6 +57,7 @@ website:
           contents:
             - docs/design/interface/outputs.qmd
             - docs/design/interface/functions.qmd
+            - docs/design/interface/supported-formats.qmd
     - id: guide
       contents:
         - section: "Guide"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -57,7 +57,7 @@ website:
           contents:
             - docs/design/interface/outputs.qmd
             - docs/design/interface/functions.qmd
-            - docs/design/interface/supported-formats.qmd
+            - docs/design/interface/inputs.qmd
     - id: guide
       contents:
         - section: "Guide"

--- a/docs/design/interface/inputs.qmd
+++ b/docs/design/interface/inputs.qmd
@@ -1,0 +1,18 @@
+---
+title: "Inputs"
+---
+
+Currently, Sprout supports the extraction of properties from the
+following data formats:
+
+```{python}
+#| echo: false
+#| output: asis
+from seedcase_sprout.core.check_is_supported_format import SUPPORTED_FORMATS
+
+print("`." + "`, `.".join(sorted(SUPPORTED_FORMATS)) + "`")
+```
+
+For more information on how to extract properties from these formats,
+see the [Creating and managing data
+resources](/docs/guides/resources.qmd) guide.

--- a/docs/design/interface/supported-formats.qmd
+++ b/docs/design/interface/supported-formats.qmd
@@ -1,0 +1,18 @@
+---
+title: "Supported data formats"
+---
+
+Currently, Sprout supports the extraction of properties from the
+following data formats:
+
+```{python}
+#| echo: false
+from seedcase_sprout.core.check_is_supported_format import SUPPORTED_FORMATS
+
+for format in sorted(SUPPORTED_FORMATS):
+    print(format)
+```
+
+For more information on how to extract properties from these formats,
+see the [Creating and managing data
+resources](/docs/guides/resources.qmd) guide.

--- a/docs/design/interface/supported-formats.qmd
+++ b/docs/design/interface/supported-formats.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Supported data formats"
+title: "Inputs"
 ---
 
 Currently, Sprout supports the extraction of properties from the

--- a/docs/design/interface/supported-formats.qmd
+++ b/docs/design/interface/supported-formats.qmd
@@ -7,10 +7,10 @@ following data formats:
 
 ```{python}
 #| echo: false
+#| output: asis
 from seedcase_sprout.core.check_is_supported_format import SUPPORTED_FORMATS
 
-for format in sorted(SUPPORTED_FORMATS):
-    print(format)
+print("`." + "`, `.".join(sorted(SUPPORTED_FORMATS)) + "`")
 ```
 
 For more information on how to extract properties from these formats,


### PR DESCRIPTION
## Description

This PR adds a doc on which data formats we support property extraction for. 

Closes #1018 

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
