### PR TITLE
feat: :sparkles: add `read_csv()` to load CSV as DataFrames

### DIFF
--- a/src/seedcase_sprout/core/read_csv.py
+++ b/src/seedcase_sprout/core/read_csv.py
@@ -30,7 +30,9 @@ def read_csv(data_path: Path) -> pl.DataFrame:
         return pl.read_csv(
             data_path,
             has_header=True,
+            # Doesn't work all the time, and we want to use properties anyway.
             infer_schema=False,
+            # Set as empty string since it will be easier to match with Frictionless.
             missing_utf8_is_empty_string=True,
         )
     except pl.exceptions.ComputeError as error:

--- a/src/seedcase_sprout/core/read_csv.py
+++ b/src/seedcase_sprout/core/read_csv.py
@@ -38,6 +38,6 @@ def read_csv(data_path: Path) -> pl.DataFrame:
             raise ValueError(
                 f"At least one row in the data file at {data_path} contains more items "
                 "than the expected number of columns. Please make sure that all rows "
-                "are the same length."
+                “have the same number of items."
             ) from error
         raise

--- a/src/seedcase_sprout/core/read_csv.py
+++ b/src/seedcase_sprout/core/read_csv.py
@@ -38,6 +38,6 @@ def read_csv(data_path: Path) -> pl.DataFrame:
             raise ValueError(
                 f"At least one row in the data file at {data_path} contains more items "
                 "than the expected number of columns. Please make sure that all rows "
-                “have the same number of items."
+                "have the same number of items."
             ) from error
         raise

--- a/src/seedcase_sprout/core/read_csv.py
+++ b/src/seedcase_sprout/core/read_csv.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import polars as pl
+
+from seedcase_sprout.core.check_is_file import check_is_file
+
+
+def read_csv(data_path: Path) -> pl.DataFrame:
+    """Loads data in the given CSV file into a Polars data frame.
+
+    Args:
+        data_path: The path to the CSV file.
+
+    Returns:
+        The Polars data frame.
+
+    Raises:
+        FileNotFoundError: If the file cannot be found or the path doesn't point to
+            a file.
+        ValueError: If the file is not a CSV file.
+        pl.exceptions.NoDataError: If the file is empty.
+        pl.exceptions.ComputeError: If the data cannot be loaded into a data frame.
+        ValueError: If the data has a row that is longer than the header row.
+    """
+    check_is_file(data_path)
+    if data_path.suffix != ".csv":
+        raise ValueError(f"{data_path} is not a CSV file.")
+
+    try:
+        return pl.read_csv(
+            data_path,
+            has_header=True,
+            infer_schema=False,
+            missing_utf8_is_empty_string=True,
+        )
+    except pl.exceptions.ComputeError as error:
+        if "found more fields than defined" in str(error):
+            raise ValueError(
+                f"At least one row in the data file at {data_path} contains more items "
+                "than the expected number of columns. Please make sure that all rows "
+                "are the same length."
+            ) from error
+        raise

--- a/tests/core/test_read_csv.py
+++ b/tests/core/test_read_csv.py
@@ -21,7 +21,7 @@ def test_throws_error_if_file_not_found(data_path):
 
 def test_throws_value_error_if_file_not_csv(tmp_path):
     """Should throw a ValueError if the file is not a CSV file."""
-    path = tmp_path / "not-data.txt"
+    path = tmp_path / "data.txt"
     path.write_text("id,name\n1,Cassidy\n2,James\n3,Björn\n")
 
     with raises(ValueError):

--- a/tests/core/test_read_csv.py
+++ b/tests/core/test_read_csv.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import polars as pl
+from polars.testing import assert_frame_equal
+from pytest import fixture, raises
+
+from seedcase_sprout.core.read_csv import read_csv
+
+
+@fixture
+def data_path(tmp_path) -> Path:
+    return tmp_path / "data.csv"
+
+
+def test_throws_error_if_file_not_found(data_path):
+    """Should throw an error if the file cannot be found."""
+
+    with raises(FileNotFoundError):
+        read_csv(data_path)
+
+
+def test_throws_value_error_if_file_not_csv(tmp_path):
+    """Should throw a ValueError if the file is not a CSV file."""
+    path = tmp_path / "not-data.txt"
+    path.write_text("id,name\n1,Cassidy\n2,James,33\n3,Björn\n")
+
+    with raises(ValueError):
+        read_csv(path)
+
+
+def test_throws_error_if_file_empty(data_path):
+    """Should throw an error if the file is empty."""
+    data_path.touch()
+
+    with raises(pl.exceptions.NoDataError):
+        read_csv(data_path)
+
+
+def test_throws_error_if_data_cannot_be_loaded(data_path):
+    """Should throw an error if the data cannot be loaded into a data frame."""
+    data_path.write_text('name\n"This quote is not escaped')
+
+    with raises(pl.exceptions.ComputeError):
+        read_csv(data_path)
+
+
+def test_schema_and_data_read_correctly(data_path):
+    """Should return a data frame with the expected schema and data."""
+    df = pl.DataFrame(
+        {"id": [1, 2, 3], "name": ["Cassidy", "James", "Björn"]},
+        schema={"id": pl.String, "name": pl.String},
+        strict=False,
+    )
+    df.write_csv(data_path)
+
+    df_read = read_csv(data_path)
+
+    assert_frame_equal(df, df_read)
+
+
+def test_nulls_read_as_empty_string(data_path):
+    """Should read null values as empty strings."""
+    df = pl.DataFrame(
+        {"id": [1, 2, 3], "name": [None] * 3},
+        schema={"id": pl.String, "name": pl.String},
+        strict=False,
+    )
+    df.write_csv(data_path)
+
+    df_read = read_csv(data_path)
+    null_column = df_read.get_column("name").to_list()
+
+    assert null_column == [""] * 3
+
+
+def test_default_value_for_missing_column_is_empty_string(data_path):
+    """When a row has no value for a column (not even null), the default value in the
+    data frame should be an empty string."""
+    data_path.write_text("id,name,age\n1,Cassidy\n2,James\n3,Björn\n")
+
+    df_read = read_csv(data_path)
+    missing_column = df_read.get_column("age").to_list()
+
+    assert missing_column == [""] * 3
+
+
+def test_throws_value_error_if_data_row_longer_than_header(data_path):
+    """Should throw ValueError if the data has a row that is longer than the header."""
+    data_path.write_text("id,name\n1,Cassidy\n2,James,33\n3,Björn\n")
+
+    with raises(ValueError):
+        read_csv(data_path)

--- a/tests/core/test_read_csv.py
+++ b/tests/core/test_read_csv.py
@@ -22,7 +22,7 @@ def test_throws_error_if_file_not_found(data_path):
 def test_throws_value_error_if_file_not_csv(tmp_path):
     """Should throw a ValueError if the file is not a CSV file."""
     path = tmp_path / "not-data.txt"
-    path.write_text("id,name\n1,Cassidy\n2,James,33\n3,Björn\n")
+    path.write_text("id,name\n1,Cassidy\n2,James\n3,Björn\n")
 
     with raises(ValueError):
         read_csv(path)


### PR DESCRIPTION
## Description

This PR adds a function to load a CSV file into a Polars data frame.

I expect this to be used used when checking data and also when converting to Parquet possibly.
In the check flow, it will look something like:
```python
def check_data(data_path: Path, resource_properties: ResourceProperties) -> Path:
    check_resource_properties(resource_properties)
    df = read_csv(data_path)  # <---
    check_data_header(df, resource_properties)
    df = set_missing_values_to_null(df, resource_properties)
    check_data_types(df, resource_properties)
    return data_path
```

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
