### PR TITLE
feat: :sparkles: add `check_data_header()`

### DIFF
--- a/src/seedcase_sprout/core/sprout_checks/check_data_header.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_header.py
@@ -5,12 +5,12 @@ from seedcase_sprout.core.properties import ResourceProperties
 
 
 def check_data_header(
-    data_frame: pl.DataFrame, resource_properties: ResourceProperties
+    data: pl.DataFrame, resource_properties: ResourceProperties
 ) -> pl.DataFrame:
     """Checks that column names in the data frame match column names in the properties.
 
     Args:
-        data_frame: The data frame to check.
+        data: The data frame to check.
         resource_properties: The resource properties to check against.
 
     Returns:
@@ -19,7 +19,7 @@ def check_data_header(
     Raises:
         ValueError: If the header doesn't match the expected column names.
     """
-    data_columns = data_frame.schema.names()
+    data_columns = data.schema.names()
     expected_columns = [
         field.name
         for field in get_nested_attr(resource_properties, "schema.fields", default=[])
@@ -29,4 +29,4 @@ def check_data_header(
             "Column names in the data frame do not match column names in the resource "
             f"properties. Expected {expected_columns}, but found {data_columns}."
         )
-    return data_frame
+    return data

--- a/src/seedcase_sprout/core/sprout_checks/check_data_header.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data_header.py
@@ -1,0 +1,32 @@
+import polars as pl
+
+from seedcase_sprout.core.get_nested_attr import get_nested_attr
+from seedcase_sprout.core.properties import ResourceProperties
+
+
+def check_data_header(
+    data_frame: pl.DataFrame, resource_properties: ResourceProperties
+) -> pl.DataFrame:
+    """Checks that column names in the data frame match column names in the properties.
+
+    Args:
+        data_frame: The data frame to check.
+        resource_properties: The resource properties to check against.
+
+    Returns:
+        The data frame, if the column names match.
+
+    Raises:
+        ValueError: If the header doesn't match the expected column names.
+    """
+    data_columns = data_frame.schema.names()
+    expected_columns = [
+        field.name
+        for field in get_nested_attr(resource_properties, "schema.fields", default=[])
+    ]
+    if data_columns != expected_columns:
+        raise ValueError(
+            "Column names in the data frame do not match column names in the resource "
+            f"properties. Expected {expected_columns}, but found {data_columns}."
+        )
+    return data_frame

--- a/tests/core/sprout_checks/test_check_data_header.py
+++ b/tests/core/sprout_checks/test_check_data_header.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import polars as pl
+from pytest import fixture, mark, raises
+
+from seedcase_sprout.core.properties import (
+    FieldProperties,
+    ResourceProperties,
+    TableSchemaProperties,
+)
+from seedcase_sprout.core.sprout_checks.check_data_header import check_data_header
+
+string_field = FieldProperties(name="my_string", type="string")
+date_field = FieldProperties(name="my_date", type="date")
+number_field = FieldProperties(name="my_number", type="number")
+
+
+@fixture
+def resource_properties() -> ResourceProperties:
+    return ResourceProperties(
+        name="data",
+        title="data",
+        path=str(Path("resources", "1", "data.csv")),
+        description="My data...",
+        schema=TableSchemaProperties(),
+    )
+
+
+def test_no_error_when_data_frame_and_properties_both_empty():
+    """Should throw no error if the data frame and the properties are both empty."""
+    df = pl.DataFrame({})
+
+    assert check_data_header(df, ResourceProperties()) is df
+
+
+def test_no_error_when_data_column_names_match_properties(resource_properties):
+    """Should throw no error if the column names in the data frame match the column
+    names in the properties."""
+    df = pl.DataFrame(
+        {
+            string_field.name: ["abc", "def"],
+            date_field.name: ["2020-12-03", "2029-09-09"],
+            number_field.name: [23, 45],
+        }
+    )
+    resource_properties.schema.fields = [string_field, date_field, number_field]
+
+    assert check_data_header(df, resource_properties) is df
+
+
+@mark.parametrize(
+    "data, fields",
+    [
+        ({"column": [123, 456]}, []),
+        ({"wrong_name": ["value"]}, [string_field]),
+        (
+            {string_field.name: ["val"], date_field.name: ["1023-02-12"]},
+            [date_field, string_field],
+        ),
+        ({date_field.name: ["2023-12-12"], "extra_name": ["val"]}, [date_field]),
+        ({date_field.name: ["2012-12-12"]}, [date_field, string_field]),
+        ({date_field.name: ["2012-12-12"], "": [""]}, [date_field, string_field]),
+    ],
+)
+def test_throws_error_when_data_column_names_do_not_match_properties(
+    data, fields, resource_properties
+):
+    """Should throw an error if the column names in the data frame don't match the
+    column names in the properties."""
+    df = pl.DataFrame(data)
+    resource_properties.schema.fields = fields
+
+    with raises(ValueError):
+        check_data_header(df, resource_properties)


### PR DESCRIPTION
## Description

This PR adds a function for checking the header of a data frame against the resource properties.
In the check flow, it will look something like:
```python
data = read_csv(data_path) 
def check_data(data: pl.DataFrame, resource_properties: ResourceProperties) -> pl.DataFrame:
    check_resource_properties(resource_properties)
    check_data_header(data, resource_properties) # <---
    data = set_missing_values_to_null(data, resource_properties)
    check_data_types(data, resource_properties)
    return data
```

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
