### PR TITLE
feat: :sparkles: add `set_missing_values_to_null()`

### DIFF
--- a/src/seedcase_sprout/core/set_missing_values_to_null.py
+++ b/src/seedcase_sprout/core/set_missing_values_to_null.py
@@ -33,6 +33,8 @@ def set_missing_values_to_null(
         pl.col(field.name).replace(
             old=schema_missing_values
             if field.missing_values is None
+            # As per Frictionless standard, field-level missing values overrides
+            # the schema-level missing values.
             else field.missing_values,
             new=None,
         )

--- a/src/seedcase_sprout/core/set_missing_values_to_null.py
+++ b/src/seedcase_sprout/core/set_missing_values_to_null.py
@@ -1,0 +1,40 @@
+import polars as pl
+
+from seedcase_sprout.core.get_nested_attr import get_nested_attr
+from seedcase_sprout.core.properties import (
+    FieldProperties,
+    ResourceProperties,
+)
+
+
+def set_missing_values_to_null(
+    data_frame: pl.DataFrame, resource_properties: ResourceProperties
+):
+    """Sets missing values to null.
+
+    Uses the resource properties to locate missing values in the data frame and sets
+    them to null.
+
+    Args:
+        data_frame: The data frame to process.
+        resource_properties: The resource properties describing the data.
+
+    Returns:
+        The updated data frame with missing values set to null.
+    """
+    fields: list[FieldProperties] = get_nested_attr(
+        resource_properties, "schema.fields", default=[]
+    )
+
+    schema_missing_values = get_nested_attr(
+        resource_properties, "schema.missing_values", default=[""]
+    )
+    return data_frame.with_columns(
+        pl.col(field.name).replace(
+            old=schema_missing_values
+            if field.missing_values is None
+            else field.missing_values,
+            new=None,
+        )
+        for field in fields
+    )

--- a/src/seedcase_sprout/core/set_missing_values_to_null.py
+++ b/src/seedcase_sprout/core/set_missing_values_to_null.py
@@ -8,7 +8,7 @@ from seedcase_sprout.core.properties import (
 
 
 def set_missing_values_to_null(
-    data_frame: pl.DataFrame, resource_properties: ResourceProperties
+    data: pl.DataFrame, resource_properties: ResourceProperties
 ):
     """Sets missing values to null.
 
@@ -16,7 +16,7 @@ def set_missing_values_to_null(
     them to null.
 
     Args:
-        data_frame: The data frame to process.
+        data: The data frame to process.
         resource_properties: The resource properties describing the data.
 
     Returns:
@@ -29,7 +29,7 @@ def set_missing_values_to_null(
     schema_missing_values = get_nested_attr(
         resource_properties, "schema.missing_values", default=[""]
     )
-    return data_frame.with_columns(
+    return data.with_columns(
         pl.col(field.name).replace(
             old=schema_missing_values
             if field.missing_values is None

--- a/tests/core/test_set_missing_values_to_null.py
+++ b/tests/core/test_set_missing_values_to_null.py
@@ -1,0 +1,201 @@
+from pathlib import Path
+
+import polars as pl
+from polars.testing import assert_frame_equal
+from pytest import fixture, mark
+
+from seedcase_sprout.core.properties import (
+    FieldProperties,
+    ResourceProperties,
+    TableSchemaProperties,
+)
+from seedcase_sprout.core.set_missing_values_to_null import set_missing_values_to_null
+
+missing_values = ["None", "NA", "*", "some text", ""]
+
+
+@fixture
+def resource_properties() -> ResourceProperties:
+    return ResourceProperties(
+        name="data",
+        title="data",
+        path=str(Path("resources", "1", "data.csv")),
+        description="My data...",
+        schema=TableSchemaProperties(),
+    )
+
+
+def test_no_null_conversion_done_when_properties_empty():
+    """No values should be set to null when the properties are empty."""
+    df = pl.DataFrame({"my_string": missing_values})
+
+    assert_frame_equal(set_missing_values_to_null(df, ResourceProperties()), df)
+
+
+def test_sets_values_in_schema_missing_values_to_null(resource_properties):
+    """Should convert values listed in `schema.missing_values` to null."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_date",
+            type="date",
+        )
+    ]
+    resource_properties.schema.missing_values = missing_values
+    df = pl.DataFrame({"my_date": ["1212-09-08"] + missing_values})
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_date").to_list() == ["1212-09-08"] + [None] * 5
+
+
+def test_sets_values_in_field_missing_values_to_null(resource_properties):
+    """Should convert values listed in `field.missing_values` to null."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_date",
+            type="date",
+            missing_values=missing_values,
+        )
+    ]
+    df = pl.DataFrame({"my_date": ["1212-09-08"] + missing_values})
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_date").to_list() == ["1212-09-08"] + [None] * 5
+
+
+@mark.parametrize("schema_missing_values", [["schema-missing-value"], [], None])
+def test_field_missing_values_override_schema_missing_values(
+    resource_properties, schema_missing_values
+):
+    """If both `schema.missing_values` and `field.missing_values` are set, the latter
+    takes precedence. Fields with a value in `schema.missing_values` are not changed to
+    null."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_string",
+            type="string",
+            missing_values=["field-missing-value"],
+        ),
+    ]
+    resource_properties.schema.missing_values = schema_missing_values
+    df = pl.DataFrame(
+        {"my_string": ["schema-missing-value", "some value", "", "field-missing-value"]}
+    )
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_string").to_list() == [
+        "schema-missing-value",
+        "some value",
+        "",
+        None,
+    ]
+
+
+@mark.parametrize("schema_missing_values", [["schema-missing-value"], [], None])
+def test_no_values_set_to_null_when_field_missing_values_empty(
+    resource_properties, schema_missing_values
+):
+    """When `field.missing_values` is set to the empty list, no value counts as missing
+    and no null conversion is done."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_string",
+            type="string",
+            missing_values=[],
+        ),
+    ]
+    resource_properties.schema.missing_values = schema_missing_values
+    df = pl.DataFrame({"my_string": ["schema-missing-value", "some value", ""]})
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_string").to_list() == [
+        "schema-missing-value",
+        "some value",
+        "",
+    ]
+
+
+def test_no_values_set_to_null_when_schema_missing_values_empty(resource_properties):
+    """When `schema.missing_values` is set to the empty list and `field.missing_values`
+    is not set, no value counts as missing and no null conversion is done."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_string",
+            type="string",
+        ),
+    ]
+    resource_properties.schema.missing_values = []
+    df = pl.DataFrame({"my_string": ["None", "some value", ""]})
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_string").to_list() == [
+        "None",
+        "some value",
+        "",
+    ]
+
+
+def test_empty_string_set_to_null_by_default(resource_properties):
+    """When missing values are not set, empty strings are set to null by default."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_string",
+            type="string",
+        ),
+    ]
+    df = pl.DataFrame({"my_string": ["None", "some value", ""]})
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_string").to_list() == [
+        "None",
+        "some value",
+        None,
+    ]
+
+
+def test_sets_value_to_null_only_if_full_match(resource_properties):
+    """A value is set to null only if it fully matches one of the missing values."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="my_date",
+            type="date",
+        )
+    ]
+    resource_properties.schema.missing_values = ["11-11"]
+    df = pl.DataFrame({"my_date": ["1234-11-11", "11-11", ""]})
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("my_date").to_list() == ["1234-11-11", None, ""]
+
+
+def test_field_missing_values_can_be_set_separately_for_each_field(resource_properties):
+    """`field.missing_values` can be set separately for each field."""
+    resource_properties.schema.fields = [
+        FieldProperties(
+            name="col1",
+            type="date",
+            missing_values=["field-1-missing"],
+        ),
+        FieldProperties(
+            name="col2",
+            type="date",
+            missing_values=["field-2-missing"],
+        ),
+    ]
+    df = pl.DataFrame(
+        {
+            "col1": ["field-1-missing", "1234-11-11"],
+            "col2": ["1010-09-08", "field-2-missing"],
+        }
+    )
+
+    df_with_nulls = set_missing_values_to_null(df, resource_properties)
+
+    assert df_with_nulls.get_column("col1").to_list() == [None, "1234-11-11"]
+    assert df_with_nulls.get_column("col2").to_list() == ["1010-09-08", None]


### PR DESCRIPTION
## Description

This PR adds a function for setting missing values (as set by the user in the resource properties) to null. Relevant Frictionless docs [here](https://datapackage.org/standard/table-schema/#missingValues) and [here](https://datapackage.org/standard/table-schema/#field-missingValues).
I expect this to be used used when checking data and also when converting to Parquet possibly.

In the check flow, it will look something like:
```python
def check_data(data_path: Path, resource_properties: ResourceProperties) -> Path:
    check_resource_properties(resource_properties)
    df = read_csv(data_path)
    check_data_header(df, resource_properties)
    df = set_missing_values_to_null(df, resource_properties)  # <---
    check_data_types(df, resource_properties)
    return data_path
```

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
