### PR TITLE
fix: :bug: fix typing of check functions

### DIFF
--- a/src/seedcase_sprout/core/sprout_checks/check_package_properties.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_package_properties.py
@@ -1,14 +1,14 @@
 from seedcase_sprout.core.checks.check_error_matcher import CheckErrorMatcher
-from seedcase_sprout.core.properties import PackageProperties
 from seedcase_sprout.core.sprout_checks.check_properties import (
     RESOURCE_FIELD_PATTERN,
     check_properties,
 )
+from seedcase_sprout.core.sprout_checks.common_types import PackagePropertiesOrDict
 
 
 def check_package_properties(
-    properties: PackageProperties | dict, ignore: list[CheckErrorMatcher] = []
-) -> PackageProperties | dict:
+    properties: PackagePropertiesOrDict, ignore: list[CheckErrorMatcher] = []
+) -> PackagePropertiesOrDict:
     """Checks that package `properties` matches requirements in Sprout.
 
     `properties` is checked against the Data Package standard and the following

--- a/src/seedcase_sprout/core/sprout_checks/check_properties.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_properties.py
@@ -2,6 +2,7 @@ from seedcase_sprout.core import checks
 from seedcase_sprout.core.checks.check_error_matcher import CheckErrorMatcher
 from seedcase_sprout.core.checks.exclude_matching_errors import exclude_matching_errors
 from seedcase_sprout.core.properties import PackageProperties
+from seedcase_sprout.core.sprout_checks.common_types import PackagePropertiesOrDict
 from seedcase_sprout.core.sprout_checks.get_sprout_package_errors import (
     get_sprout_package_errors,
 )
@@ -13,8 +14,8 @@ RESOURCE_FIELD_PATTERN = r"resources\[\d+\]"
 
 
 def check_properties(
-    properties: PackageProperties | dict, ignore: list[CheckErrorMatcher] = []
-) -> PackageProperties | dict:
+    properties: PackagePropertiesOrDict, ignore: list[CheckErrorMatcher] = []
+) -> PackagePropertiesOrDict:
     """Checks that `properties` matches requirements in Sprout.
 
     `properties` is checked against the Data Package standard and the following

--- a/src/seedcase_sprout/core/sprout_checks/check_resource_properties.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_resource_properties.py
@@ -1,13 +1,14 @@
 from seedcase_sprout.core.checks.check_error_matcher import CheckErrorMatcher
 from seedcase_sprout.core.properties import ResourceProperties
 from seedcase_sprout.core.sprout_checks.check_properties import check_properties
+from seedcase_sprout.core.sprout_checks.common_types import ResourcePropertiesOrDict
 
 PACKAGE_FIELD_PATTERN = r"\$\.\w+$"
 
 
 def check_resource_properties(
-    properties: ResourceProperties | dict, ignore: list[CheckErrorMatcher] = []
-) -> ResourceProperties | dict:
+    properties: ResourcePropertiesOrDict, ignore: list[CheckErrorMatcher] = []
+) -> ResourcePropertiesOrDict:
     """Checks that resource `properties` matches requirements in Sprout.
 
     `properties` is checked against the Data Package standard and the following

--- a/src/seedcase_sprout/core/sprout_checks/common_types.py
+++ b/src/seedcase_sprout/core/sprout_checks/common_types.py
@@ -1,0 +1,10 @@
+from typing import Any, TypeVar
+
+from seedcase_sprout.core.properties import PackageProperties, ResourceProperties
+
+PackagePropertiesOrDict = TypeVar(
+    "PackagePropertiesOrDict", PackageProperties, dict[str, Any]
+)
+ResourcePropertiesOrDict = TypeVar(
+    "ResourcePropertiesOrDict", ResourceProperties, dict[str, Any]
+)


### PR DESCRIPTION
## Description

This PR fixes the typing of check functions that accept either a dict or a `Properties`.

The problem with the original version was that a return type of `PackageProperties | dict` is too broad. For example, VS code thinks that all methods on dict and all methods on `PackageProperties` are available on the output. But that is not true.
![bad](https://github.com/user-attachments/assets/95e11175-18bd-4e65-a62f-bebbf8529731)

But we can restrict the type of the output because we know that it is the same as the type of the input. Now VS code can infer the methods available on the output correctly:
![good](https://github.com/user-attachments/assets/082ae709-a3cc-43a5-992a-2cc3ce53dc4b)

I guess this would have been flagged by mypy?

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
