### PR TITLE
refactor: :recycle: remove original extension and `.gz` from batch file names

### DIFF
--- a/src/seedcase_sprout/core/create_batch_file_name.py
+++ b/src/seedcase_sprout/core/create_batch_file_name.py
@@ -11,6 +11,6 @@ def create_batch_file_name(path: Path) -> str:
         path: The path to the batch file to extract the original extension from.
 
     Returns:
-        The created batch file name in the format {timestamp}-{uuid}{ext}.gz
+        The created batch file name in the format {timestamp}-{uuid}{ext}
     """
-    return f"{get_compact_iso_timestamp()}-{uuid4()}{path.suffix}.gz"
+    return f"{get_compact_iso_timestamp()}-{uuid4()}{path.suffix}"

--- a/src/seedcase_sprout/core/create_batch_file_name.py
+++ b/src/seedcase_sprout/core/create_batch_file_name.py
@@ -1,16 +1,15 @@
-from pathlib import Path
 from uuid import uuid4
 
 from seedcase_sprout.core.get_iso_timestamp import get_compact_iso_timestamp
 
 
-def create_batch_file_name(path: Path) -> str:
+def create_batch_file_name() -> str:
     """Creates a unique filename for a batch file.
 
     Args:
         path: The path to the batch file to extract the original extension from.
 
     Returns:
-        The created batch file name in the format {timestamp}-{uuid}{ext}
+        The created batch file name in the format {timestamp}-{uuid}
     """
-    return f"{get_compact_iso_timestamp()}-{uuid4()}{path.suffix}"
+    return f"{get_compact_iso_timestamp()}-{uuid4()}"

--- a/tests/core/test_create_batch_file_name.py
+++ b/tests/core/test_create_batch_file_name.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from pathlib import Path
 from unittest.mock import patch
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -11,7 +10,7 @@ from seedcase_sprout.core.create_batch_file_name import create_batch_file_name
 
 @patch("seedcase_sprout.core.create_batch_file_name.uuid4", return_value=UUID(int=1))
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1, tzinfo=ZoneInfo("UTC")), tick=False)
-def test_returns_expected_batch_file_name(mock_uuid, tmp_path):
-    path = create_batch_file_name(Path(tmp_path) / "test.csv")
+def test_returns_expected_batch_file_name(mock_uuid):
+    file_name = create_batch_file_name()
 
-    assert path == f"2024-05-14T050001Z-{mock_uuid()}.csv"
+    assert file_name == f"2024-05-14T050001Z-{mock_uuid()}"

--- a/tests/core/test_create_batch_file_name.py
+++ b/tests/core/test_create_batch_file_name.py
@@ -14,4 +14,4 @@ from seedcase_sprout.core.create_batch_file_name import create_batch_file_name
 def test_returns_expected_batch_file_name(mock_uuid, tmp_path):
     path = create_batch_file_name(Path(tmp_path) / "test.csv")
 
-    assert path == f"2024-05-14T050001Z-{mock_uuid()}.csv.gz"
+    assert path == f"2024-05-14T050001Z-{mock_uuid()}.csv"

--- a/tests/core/test_path_local.py
+++ b/tests/core/test_path_local.py
@@ -22,10 +22,8 @@ def tmp_package(tmp_path):
     """Set up a test data package with two resources."""
     create_test_data_package(tmp_path)
 
-    create_test_resource_structure(tmp_path, ["batch_file_1.csv.gz"])
-    create_test_resource_structure(
-        tmp_path, ["batch_file_2.csv.gz", "batch_file_3.csv.gz"]
-    )
+    create_test_resource_structure(tmp_path, ["batch_file_1.csv"])
+    create_test_resource_structure(tmp_path, ["batch_file_2.csv", "batch_file_3.csv"])
 
     return tmp_path
 
@@ -91,8 +89,8 @@ def test_path_resource_batch_files_returns_expected_list_of_paths(tmp_package):
     # Then
     assert set(path_resource_batch_files(resource_id=2, path=tmp_package)) == set(
         [
-            resource_batch_path / "batch_file_2.csv.gz",
-            resource_batch_path / "batch_file_3.csv.gz",
+            resource_batch_path / "batch_file_2.csv",
+            resource_batch_path / "batch_file_3.csv",
         ]
     )
 

--- a/tests/core/test_path_local.py
+++ b/tests/core/test_path_local.py
@@ -22,8 +22,10 @@ def tmp_package(tmp_path):
     """Set up a test data package with two resources."""
     create_test_data_package(tmp_path)
 
-    create_test_resource_structure(tmp_path, ["batch_file_1.csv"])
-    create_test_resource_structure(tmp_path, ["batch_file_2.csv", "batch_file_3.csv"])
+    create_test_resource_structure(tmp_path, ["batch_file_1.parquet"])
+    create_test_resource_structure(
+        tmp_path, ["batch_file_2.parquet", "batch_file_3.parquet"]
+    )
 
     return tmp_path
 
@@ -89,8 +91,8 @@ def test_path_resource_batch_files_returns_expected_list_of_paths(tmp_package):
     # Then
     assert set(path_resource_batch_files(resource_id=2, path=tmp_package)) == set(
         [
-            resource_batch_path / "batch_file_2.csv",
-            resource_batch_path / "batch_file_3.csv",
+            resource_batch_path / "batch_file_2.parquet",
+            resource_batch_path / "batch_file_3.parquet",
         ]
     )
 


### PR DESCRIPTION
## Description

Since we won’t compress these files after all, now that we’ll store batch files as Parquet.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Added or updated tests
- [X] Ran `just run-all`
