### PR TITLE
fix: :bug: check that package and resource properties are `dict`s

### DIFF
--- a/src/seedcase_sprout/core/sprout_checks/check_properties.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_properties.py
@@ -44,11 +44,13 @@ def check_properties(
     )
 
     errors = checks.check_properties(properties_dict)
-    errors += get_sprout_package_errors(properties_dict)
 
-    if isinstance(properties_dict.get("resources"), list):
-        for index, resource in enumerate(properties_dict.get("resources")):
-            errors += get_sprout_resource_errors(resource, index)
+    if isinstance(properties_dict, dict):
+        errors += get_sprout_package_errors(properties_dict)
+        if isinstance(properties_dict.get("resources"), list):
+            for index, resource in enumerate(properties_dict.get("resources")):
+                if isinstance(resource, dict):
+                    errors += get_sprout_resource_errors(resource, index)
 
     errors = exclude_matching_errors(
         errors,

--- a/src/seedcase_sprout/core/sprout_checks/check_resource_properties.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_resource_properties.py
@@ -43,7 +43,7 @@ def check_resource_properties(
         )
     except ExceptionGroup as error_info:
         for error in error_info.exceptions:
-            error.json_path = error.json_path.replace("resources[0].", "")
+            error.json_path = error.json_path.replace(".resources[0]", "")
         raise error_info
 
     return properties

--- a/tests/core/sprout_checks/test_check_properties_sprout.py
+++ b/tests/core/sprout_checks/test_check_properties_sprout.py
@@ -163,6 +163,30 @@ def test_raises_error_for_only_sprout_specific_errors(properties):
     )
 
 
+def test_raises_error_if_package_properties_not_dict():
+    """A `CheckError` should be raised if the package properties is not a dict."""
+    with raises(ExceptionGroup) as error_info:
+        check_properties([1, 2, 3])
+
+    errors = error_info.value.exceptions
+    assert len(errors) == 1
+    assert errors[0].json_path == "$"
+    assert errors[0].validator == "type"
+
+
+def test_raises_error_if_resource_properties_not_dict(properties):
+    """A `CheckError` should be raised if a resource properties is not a dict."""
+    properties["resources"][0] = [1, 2, 3]
+
+    with raises(ExceptionGroup) as error_info:
+        check_properties(properties)
+
+    errors = error_info.value.exceptions
+    assert len(errors) == 1
+    assert errors[0].json_path == "$.resources[0]"
+    assert errors[0].validator == "type"
+
+
 def test_ignored_errors_should_not_make_check_fail():
     """Check should not fail if triggered by an error that is ignored."""
     assert check_properties({}, ignore=[CheckErrorMatcher(validator="required")]) == {}

--- a/tests/core/sprout_checks/test_check_resource_properties_sprout.py
+++ b/tests/core/sprout_checks/test_check_resource_properties_sprout.py
@@ -146,6 +146,17 @@ def test_error_raised_for_mismatched_type(properties):
     assert errors[0].validator == "type"
 
 
+def test_raises_error_if_resource_properties_not_dict(properties):
+    """A `CheckError` should be raised if the resource properties is not a dict."""
+    with raises(ExceptionGroup) as error_info:
+        check_resource_properties([1, 2, 3])
+
+    errors = error_info.value.exceptions
+    assert len(errors) == 1
+    assert errors[0].json_path == "$"
+    assert errors[0].validator == "type"
+
+
 def test_error_raised_for_only_sprout_specific_errors(properties):
     """Errors should be triggered by only those Data Package standard violations that
     are relevant for Sprout."""


### PR DESCRIPTION
## Description

This PR adds two missing instance checks in the Sprout-specific `check_properties`. Without these the test cases I've added fail.



<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
