### PR TITLE
docs: :pencil2: add resource guide to guide sidebar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -66,6 +66,7 @@ website:
           contents:
             - docs/guide/installation.qmd
             - docs/guide/packages.qmd
+            - docs/guide/resources.qmd
             - docs/guide/checks.qmd
 
 quartodoc:


### PR DESCRIPTION
## Description

Seems like we forgot to add the resource guide to the sidebar, when we added the guide. 

Alternatively, we could do something like: 

```
contents: 
          - auto: "docs/guide/*.qmd” 
```

So we don’t have to update the sidebar with new guides. But then we won’t get the order that we want.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
