### PR TITLE
chore: 👩‍💻 use asterisk to include all guides in sidebar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -64,10 +64,7 @@ website:
         - section: "Guide"
           href: docs/guide/index.qmd
           contents:
-            - docs/guide/installation.qmd
-            - docs/guide/packages.qmd
-            - docs/guide/resources.qmd
-            - docs/guide/checks.qmd
+           - auto: "docs/guide/*.qmd"
 
 quartodoc:
   sidebar: "docs/reference/_sidebar.yml"

--- a/docs/guide/checks.qmd
+++ b/docs/guide/checks.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Checking package and resource properties"
-order: 2
+order: 4
 jupyter: python3
 ---
 


### PR DESCRIPTION
## Description

The reason we thought the ordering didn't work with `*` was that we actually had two documents with `order: 2`.
Now, we only have to remember to add the order—we don’t have to remember to add it to the sidebar 🙌 

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
