### PR TITLE
build: :heavy_plus_sign: Quarto seems to need pyyaml in GitHub workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "jupyter>=1.1.1",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
+    "pyyaml>=6.0.2",
     "quartodoc>=0.9.1",
     "ruff>=0.11.4",
     "time-machine>=2.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2000,7 +2000,7 @@ wheels = [
 
 [[package]]
 name = "seedcase-sprout"
-version = "0.29.1"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "dacite" },
@@ -2018,6 +2018,7 @@ dev = [
     { name = "jupyter" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "quartodoc" },
     { name = "ruff" },
     { name = "time-machine" },
@@ -2040,6 +2041,7 @@ dev = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "quartodoc", specifier = ">=0.9.1" },
     { name = "ruff", specifier = ">=0.11.4" },
     { name = "time-machine", specifier = ">=2.16.0" },


### PR DESCRIPTION
## Description

The switch to uv broke how Quarto built things. It says it is missing this package, so I am testing this to see if it will build now.

Doesn't need a review.