### PR TITLE
refactor: :recycle: simplify imports and `__init__.py` file

### DIFF
--- a/src/seedcase_sprout/core/__init__.py
+++ b/src/seedcase_sprout/core/__init__.py
@@ -43,13 +43,10 @@ from .update_package_properties import update_package_properties
 from .write_file import write_file
 from .write_package_properties import write_package_properties
 
-# from .edit_resource_properties import *
+# from .update_resource_properties import *
 # from .write_resource_data_to_batch import *
 # from .write_resource_parquet import *
 from .write_resource_properties import write_resource_properties
-
-# Helpers -----
-# from .pretty_json import *
 
 __all__ = [
     # Properties -----
@@ -73,7 +70,6 @@ __all__ = [
     "example_resource_properties_all_types",
     # Packages -----
     "update_package_properties",
-    "edit_package_properties",
     "write_package_properties",
     "as_readme_text",
     # "delete_package",
@@ -82,7 +78,7 @@ __all__ = [
     "create_resource_properties",
     "extract_resource_properties",
     "read_resource_batches",
-    # "edit_resource_properties",
+    # "update_resource_properties",
     # "write_resource_data_to_batch",
     # "write_resource_parquet",
     "write_resource_properties",

--- a/src/seedcase_sprout/core/extract_resource_properties.py
+++ b/src/seedcase_sprout/core/extract_resource_properties.py
@@ -14,7 +14,7 @@ def extract_resource_properties(data_path: Path) -> ResourceProperties:
 
     This function takes the data file found at the `data_path` location and
     extracts properties from the file into a `ResourceProperties` object. This
-    function is often followed by `edit_resource_properties()` to fill in any
+    function is often followed by `update_resource_properties()` to fill in any
     remaining missing fields, like the `path` property field.  Usually, you use
     either this function or the `create_resource_properties()` function to
     create the initial resource properties for a specific (new) data resource.

--- a/tests/core/test_as_readme_text.py
+++ b/tests/core/test_as_readme_text.py
@@ -1,9 +1,9 @@
-from seedcase_sprout.core.as_readme_text import as_readme_text
-from seedcase_sprout.core.properties import (
+from seedcase_sprout.core import (
     ContributorProperties,
     LicenseProperties,
     PackageProperties,
     ResourceProperties,
+    as_readme_text,
 )
 
 


### PR DESCRIPTION
## Description

Some very minor revisions to how the imports were written, plus removing some left over/renamed items in the `__init__.py`.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
