### PR TITLE
feat: :sparkles: use `check_data()` in `read_resource_batches()`

### DIFF
--- a/src/seedcase_sprout/core/read_resource_batches.py
+++ b/src/seedcase_sprout/core/read_resource_batches.py
@@ -11,8 +11,7 @@ from seedcase_sprout.core.constants import (
     BATCH_TIMESTAMP_PATTERN,
 )
 from seedcase_sprout.core.properties import ResourceProperties
-
-# from seedcase_sprout.core.checks.check_data import check_data
+from seedcase_sprout.core.sprout_checks.check_data import check_data
 from seedcase_sprout.core.sprout_checks.check_properties import (
     check_resource_properties,
 )
@@ -87,8 +86,7 @@ def read_resource_batches(
 
     data_list = list(map(_read_parquet_batch_file, paths))
 
-    # TODO: Uncomment and test when `check_data` is implemented
-    # list(map(check_data, data_list, resource_properties))
+    list(map(lambda data: check_data(data, resource_properties), data_list))
 
     return data_list
 

--- a/src/seedcase_sprout/core/read_resource_batches.py
+++ b/src/seedcase_sprout/core/read_resource_batches.py
@@ -83,15 +83,12 @@ def read_resource_batches(
     """
     list(map(check_is_file, paths))
     check_resource_properties(resource_properties)
-
-    data_list = list(map(_read_parquet_batch_file, paths))
-
-    list(map(lambda data: check_data(data, resource_properties), data_list))
-
-    return data_list
+    return [_read_parquet_batch_file(path, resource_properties) for path in paths]
 
 
-def _read_parquet_batch_file(path: Path) -> pl.DataFrame:
+def _read_parquet_batch_file(
+    path: Path, resource_properties: ResourceProperties
+) -> pl.DataFrame:
     """Reads a Parquet batch file and adds the timestamp as a column.
 
     This function reads a Parquet batch file into a Polars DataFrame and adds
@@ -99,11 +96,14 @@ def _read_parquet_batch_file(path: Path) -> pl.DataFrame:
 
     Args:
         path: Path to the Parquet batch file.
+        resource_properties: The resource properties to check the data against.
 
     Returns:
         The Parquet file as a DataFrame with a timestamp column added.
     """
     data = pl.read_parquet(path)
+    check_data(data, resource_properties)
+
     timestamp = _extract_timestamp_from_batch_file_path(path)
     _check_batch_file_timestamp(timestamp)
     data = _add_timestamp_as_column(data, timestamp)

--- a/src/seedcase_sprout/core/sprout_checks/check_data.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data.py
@@ -39,8 +39,9 @@ def check_data(
         Output the `data` if checks all pass.
 
     Raises:
-        ExceptionGroup: A list of messages that highlight where there are differences
-            between the data and the properties.
+        ExceptionGroup[CheckError]: If the resource properties are incorrect.
+        ValueError: If column names in the data are incorrect.
+        ExceptionGroup[ValueError]: If data types in the data are incorrect.
 
     Examples:
         ```{python}

--- a/src/seedcase_sprout/core/sprout_checks/check_data.py
+++ b/src/seedcase_sprout/core/sprout_checks/check_data.py
@@ -44,9 +44,9 @@ def check_data(
 
     Examples:
         ```{python}
-        import seedcase_sprout as sp
+        import seedcase_sprout.core as sp
 
-        check_data(
+        sp.check_data(
             data=sp.example_data(),
             resource_properties=sp.example_resource_properties()
         )

--- a/tests/core/assert_raises_errors.py
+++ b/tests/core/assert_raises_errors.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+from pytest import raises
+
+from seedcase_sprout.core.check_datapackage.check_error import CheckError
+
+
+def assert_raises_errors(
+    fn: Callable, error_type: type[BaseException], error_count: int = None
+) -> None:
+    """Asserts that the function raises a group of errors of the given type."""
+    with raises(ExceptionGroup) as error_info:
+        fn()
+
+    errors = error_info.value.exceptions
+    assert all(isinstance(error, error_type) for error in errors)
+    if error_count is not None:
+        assert len(errors) == error_count
+
+
+def assert_raises_check_errors(fn: Callable, error_count: int = None) -> None:
+    """Asserts that the function raises a group of `CheckError`s."""
+    assert_raises_errors(fn, CheckError, error_count)

--- a/tests/core/sprout_checks/test_check_data.py
+++ b/tests/core/sprout_checks/test_check_data.py
@@ -20,6 +20,10 @@ from seedcase_sprout.core.sprout_checks._check_column_types import (
     _FRICTIONLESS_TO_ALLOWED_POLARS_TYPES,
 )
 from seedcase_sprout.core.sprout_checks.check_data import check_data
+from tests.core.assert_raises_errors import (
+    assert_raises_check_errors,
+    assert_raises_errors,
+)
 
 string_field = FieldProperties(name="my_string", type="string")
 bool_field = FieldProperties(name="my_bool", type="boolean")
@@ -193,11 +197,7 @@ def test_rejects_geopoint_with_incorrect_size():
         FieldProperties(name="my_geopoint", type="geopoint")
     ]
 
-    with raises(ExceptionGroup) as error_info:
-        check_data(data, resource_properties)
-
-    errors = error_info.value.exceptions
-    assert len(errors) == 1
+    assert_raises_errors(lambda: check_data(data, resource_properties), ValueError, 1)
 
 
 def test_rejects_geopoint_with_incorrect_inner_type():
@@ -211,8 +211,9 @@ def test_rejects_geopoint_with_incorrect_inner_type():
         FieldProperties(name="my_geopoint", type="geopoint")
     ]
 
-    with raises(ExceptionGroup) as error_info:
-        check_data(data, resource_properties)
+    assert_raises_errors(lambda: check_data(data, resource_properties), ValueError, 1)
 
-    errors = error_info.value.exceptions
-    assert len(errors) == 1
+
+def test_rejects_incorrect_resource_properties():
+    """Should throw an error if the resource properties are incorrect."""
+    assert_raises_check_errors(lambda: check_data(example_data(), ResourceProperties()))

--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -1,8 +1,11 @@
 from seedcase_sprout.core.examples import (
+    example_data,
+    example_data_all_types,
     example_package_properties,
     example_resource_properties,
     example_resource_properties_all_types,
 )
+from seedcase_sprout.core.sprout_checks.check_data import check_data
 from seedcase_sprout.core.sprout_checks.check_properties import (
     check_package_properties,
     check_resource_properties,
@@ -21,15 +24,11 @@ def test_creates_correct_resource_properties_object_all_types():
     assert check_resource_properties(example_resource_properties_all_types())
 
 
-def xtest_example_data_matches_resource_properties():
-    # TODO: Update when `check_data()` has been finished
-    # data = example_data()
-    # assert check_data(data, example_resource_properties()) is data
-    ...
+def test_example_data_matches_resource_properties():
+    data = example_data()
+    assert check_data(data, example_resource_properties()) is data
 
 
-def xtest_example_data_matches_resource_properties_all_types():
-    # TODO: Update when `check_data()` has been finished
-    # data = example_data_all_types()
-    # assert check_data(data, example_resource_properties_all_types()) is data
-    ...
+def test_example_data_matches_resource_properties_all_types():
+    data = example_data_all_types()
+    assert check_data(data, example_resource_properties_all_types()) is data

--- a/tests/core/test_read_resource_batches.py
+++ b/tests/core/test_read_resource_batches.py
@@ -13,6 +13,9 @@ from seedcase_sprout.core.properties import (
 from seedcase_sprout.core.read_resource_batches import (
     read_resource_batches,
 )
+from tests.core.assert_raises_errors import (
+    assert_raises_check_errors,
+)
 from tests.core.directory_structure_setup import (
     create_test_data_package,
 )
@@ -161,28 +164,23 @@ def test_if_multiple_correct_timestamps_in_file_name_use_first_one(resource_path
     assert data_list[0][BATCH_TIMESTAMP_COLUMN_NAME][0] == "2025-03-26T100346Z"
 
 
-def xtest_raises_error_when_properties_do_not_match_data(resource_paths):
+def test_raises_error_when_properties_do_not_match_data(resource_paths):
     """Raises errors from checks when the resource properties don't match the data."""
     # Given
     resource_properties.schema.fields[0].name = "not-id"
 
     # When, Then
-    # TODO: Uncomment and add asserts when `check_data()` is implemented.
-    # with raises(ExceptionGroup) as error_info:
-    #     read_resource_batches(
-    #         paths=resource_paths, resource_properties=resource_properties
-    #     )
-
-    # errors = error_info.value.exceptions
+    with raises(ValueError):
+        read_resource_batches(
+            paths=resource_paths, resource_properties=resource_properties
+        )
 
 
-def xtest_raises_error_with_empty_resource_properties():
+def test_raises_error_with_empty_resource_properties(resource_paths):
     """Raises errors from checks if the resource properties are empty."""
     # When, Then
-    # TODO: Uncomment and add asserts when `check_data()` is implemented.
-    # with raises(ExceptionGroup) as error_info:
-    #     read_resource_batches(
-    #         paths=resource_paths, resource_properties=ResourceProperties()
-    #     )
-
-    # errors = error_info.value.exceptions
+    assert_raises_check_errors(
+        lambda: read_resource_batches(
+            paths=resource_paths, resource_properties=ResourceProperties()
+        )
+    )


### PR DESCRIPTION
## Description

This PR finishes `check_data()` and adds it to `read_resource_batches()` plus:

- tidies tests
- uncomments references in calling code
- fixes resulting errors

Closes #1237 

<!-- Select quick/in-depth as necessary -->
This PR needs a medium-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
