### PR TITLE
refactor: :recycle: get cwd at call time in `PackagePath`

### DIFF
--- a/src/seedcase_sprout/core/paths.py
+++ b/src/seedcase_sprout/core/paths.py
@@ -46,9 +46,9 @@ class PackagePath:
         ```
     """
 
-    def __init__(self, path: Path = Path.cwd()) -> Path:
+    def __init__(self, path: Path | None = None) -> Path:
         """Set the base path."""
-        self.path = path
+        self.path = path or Path.cwd()
 
     def properties(self) -> Path:
         """Path to the `datapackage.json` file."""

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -1,3 +1,5 @@
+import os
+
 from seedcase_sprout.core import PackagePath
 
 
@@ -14,3 +16,15 @@ def test_package_path_outputs_an_absolute_path(tmp_path):
     assert path.resource_data("test").is_absolute()
     assert path.resource_batch("test").is_absolute()
     # TODO: Test `resource_batch_files()` after deciding whether to do a check first?
+
+
+def test_path_defaults_to_cwd_at_call_time(tmp_path):
+    """When no root path is provided, the root path should default to the cwd of the
+    calling script."""
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        package_path = PackagePath()
+        assert package_path.path == tmp_path
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
## Description

This PR makes `PackagePath` usable in more situations by setting the default path (the cwd) at call time (not at definition time).

For a use case, see the test I added.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
