### PR TITLE
build: :bug: needs to be numeric in order to build the website

### DIFF
--- a/src/seedcase_sprout/core/read_resource_batches.py
+++ b/src/seedcase_sprout/core/read_resource_batches.py
@@ -70,7 +70,7 @@ def read_resource_batches(
                 {
                     "id": [1, 2, 3],
                     "name": ["anne", "belinda", "charlotte"],
-                    "value": [10, 20, 30],
+                    "value": [10.2, 20.1, 30.2],
                 }
             )
             data.write_parquet(batch_file_path)


### PR DESCRIPTION
## Description

The website stopped building because the docstrings needed to be a number, not integer.

<!-- Select quick/in-depth as necessary -->
Does not need a review.
## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
