### PR TITLE
refactor: :recycle: create a simpler map functional

### DIFF
--- a/src/seedcase_sprout/core/create_dirs.py
+++ b/src/seedcase_sprout/core/create_dirs.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import seedcase_sprout.core.fp as fp
+import seedcase_sprout.core.internals as _map
 
 
 def create_dir(path: Path) -> Path:
@@ -27,5 +27,5 @@ def create_dirs(paths: list[Path]) -> list[Path]:
     Returns:
         A list of paths to the newly created directories.
     """
-    created_dirs = fp._map(paths, create_dir)
+    created_dirs = _map(paths, create_dir)
     return created_dirs

--- a/src/seedcase_sprout/core/create_dirs.py
+++ b/src/seedcase_sprout/core/create_dirs.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import seedcase_sprout.core.fp as fp
+
 
 def create_dir(path: Path) -> Path:
     """Creates a directory from a path.
@@ -25,5 +27,5 @@ def create_dirs(paths: list[Path]) -> list[Path]:
     Returns:
         A list of paths to the newly created directories.
     """
-    created_dirs = [create_dir(path) for path in paths]
+    created_dirs = fp._map(paths, create_dir)
     return created_dirs

--- a/src/seedcase_sprout/core/create_dirs.py
+++ b/src/seedcase_sprout/core/create_dirs.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import seedcase_sprout.core.internals as _map
+from seedcase_sprout.core.internals import _map
 
 
 def create_dir(path: Path) -> Path:

--- a/src/seedcase_sprout/core/fp.py
+++ b/src/seedcase_sprout/core/fp.py
@@ -2,5 +2,29 @@
 
 
 def _map(x: list, fn: callable) -> list:
-    """Map a function over a list."""
+    """Use a function on each item in a list.
+
+    This is a simpler, more user-friendly version of the built-in `map()`
+    function. This function takes a list and a function, applies the function
+    to each item in the list, and returns a new list with the results.
+    This is mostly a wrapper around the built-in `map()` function.
+
+    Inspired from the functionals from the R package purrr.
+
+    Args:
+        x: A list object.
+        fn: A function to use on each item in the list `x`.
+
+    Returns:
+        A list with the results of applying `fn` to each item in `x`.
+        The length of the list is the same as `x`.
+
+    Examples:
+        ```{python}
+        import seedcase_sprout.core.fp as fp
+        def square(x):
+            return x * x
+        fp._map([1, 2, 3], square)
+        ```
+    """
     return list(map(fn, x))

--- a/src/seedcase_sprout/core/fp.py
+++ b/src/seedcase_sprout/core/fp.py
@@ -1,0 +1,6 @@
+"""Mimicking the functional programming tools from R and the R package purrr."""
+
+
+def _map(x: list, fn: callable) -> list:
+    """Map a function over a list."""
+    return list(map(fn, x))

--- a/src/seedcase_sprout/core/get_ids.py
+++ b/src/seedcase_sprout/core/get_ids.py
@@ -1,6 +1,8 @@
 import re
 from pathlib import Path
 
+import seedcase_sprout.core.fp as fp
+
 
 def get_ids(path: Path) -> list[int]:
     """Gets the ids of existing resources or packages in a directory.
@@ -14,7 +16,7 @@ def get_ids(path: Path) -> list[int]:
     """
     # Keep only directories
     dirs = list(path.glob("*/"))
-    ids = list(map(get_number_from_dir, dirs))
+    ids = fp._map(dirs, get_number_from_dir)
     # Drop any empty items
     ids = sorted(filter(None, ids))
 

--- a/src/seedcase_sprout/core/get_ids.py
+++ b/src/seedcase_sprout/core/get_ids.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-import seedcase_sprout.core.fp as fp
+import seedcase_sprout.core.internals as _map
 
 
 def get_ids(path: Path) -> list[int]:
@@ -16,7 +16,7 @@ def get_ids(path: Path) -> list[int]:
     """
     # Keep only directories
     dirs = list(path.glob("*/"))
-    ids = fp._map(dirs, get_number_from_dir)
+    ids = _map(dirs, get_number_from_dir)
     # Drop any empty items
     ids = sorted(filter(None, ids))
 

--- a/src/seedcase_sprout/core/get_ids.py
+++ b/src/seedcase_sprout/core/get_ids.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-import seedcase_sprout.core.internals as _map
+from seedcase_sprout.core.internals import _map
 
 
 def get_ids(path: Path) -> list[int]:

--- a/src/seedcase_sprout/core/internals/__init__.py
+++ b/src/seedcase_sprout/core/internals/__init__.py
@@ -1,0 +1,3 @@
+"""Internal functions"""
+
+from .functionals import _map

--- a/src/seedcase_sprout/core/internals/__init__.py
+++ b/src/seedcase_sprout/core/internals/__init__.py
@@ -1,3 +1,3 @@
-"""Internal functions"""
+"""Internal functions."""
 
 from .functionals import _map

--- a/src/seedcase_sprout/core/internals/functionals.py
+++ b/src/seedcase_sprout/core/internals/functionals.py
@@ -1,5 +1,7 @@
 """Mimicking the functional programming tools from R and the R package purrr."""
 
+from typing import Callable
+
 
 def _map(x: list, fn: Callable) -> list:
     """Use a function on each item in a list.

--- a/src/seedcase_sprout/core/internals/functionals.py
+++ b/src/seedcase_sprout/core/internals/functionals.py
@@ -21,10 +21,10 @@ def _map(x: list, fn: callable) -> list:
 
     Examples:
         ```{python}
-        import seedcase_sprout.core.fp as fp
+        from seedcase_sprout.core.internals import _map
         def square(x):
             return x * x
-        fp._map([1, 2, 3], square)
+        _map([1, 2, 3], square)
         ```
     """
     return list(map(fn, x))

--- a/src/seedcase_sprout/core/internals/functionals.py
+++ b/src/seedcase_sprout/core/internals/functionals.py
@@ -1,7 +1,7 @@
 """Mimicking the functional programming tools from R and the R package purrr."""
 
 
-def _map(x: list, fn: callable) -> list:
+def _map(x: list, fn: Callable) -> list:
     """Use a function on each item in a list.
 
     This is a simpler, more user-friendly version of the built-in `map()`

--- a/src/seedcase_sprout/core/read_resource_batches.py
+++ b/src/seedcase_sprout/core/read_resource_batches.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import polars as pl
 
-import seedcase_sprout.core.fp as fp
+import seedcase_sprout.core.internals as _map
 from seedcase_sprout.core.check_is_file import check_is_file
 from seedcase_sprout.core.constants import (
     BATCH_TIMESTAMP_COLUMN_NAME,
@@ -82,7 +82,7 @@ def read_resource_batches(
             )
         ```
     """
-    fp._map(paths, check_is_file)
+    _map(paths, check_is_file)
     check_resource_properties(resource_properties)
     return [_read_parquet_batch_file(path, resource_properties) for path in paths]
 

--- a/src/seedcase_sprout/core/read_resource_batches.py
+++ b/src/seedcase_sprout/core/read_resource_batches.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 import polars as pl
 
-import seedcase_sprout.core.internals as _map
 from seedcase_sprout.core.check_is_file import check_is_file
 from seedcase_sprout.core.constants import (
     BATCH_TIMESTAMP_COLUMN_NAME,
     BATCH_TIMESTAMP_FORMAT,
     BATCH_TIMESTAMP_PATTERN,
 )
+from seedcase_sprout.core.internals import _map
 from seedcase_sprout.core.properties import ResourceProperties
 from seedcase_sprout.core.sprout_checks.check_data import check_data
 from seedcase_sprout.core.sprout_checks.check_properties import (

--- a/src/seedcase_sprout/core/read_resource_batches.py
+++ b/src/seedcase_sprout/core/read_resource_batches.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import polars as pl
 
+import seedcase_sprout.core.fp as fp
 from seedcase_sprout.core.check_is_file import check_is_file
 from seedcase_sprout.core.constants import (
     BATCH_TIMESTAMP_COLUMN_NAME,
@@ -81,7 +82,7 @@ def read_resource_batches(
             )
         ```
     """
-    list(map(check_is_file, paths))
+    fp._map(paths, check_is_file)
     check_resource_properties(resource_properties)
     return [_read_parquet_batch_file(path, resource_properties) for path in paths]
 

--- a/tests/core/test_create_resource_structure.py
+++ b/tests/core/test_create_resource_structure.py
@@ -1,11 +1,11 @@
 from pytest import raises
 
-import seedcase_sprout.core as sp
+from seedcase_sprout.core import create_resource_structure
 
 
 def test_returns_resource_structure_when_no_resources_exist(tmp_path):
     """Returns the paths to the resource and batch data folder."""
-    lst_created_paths = sp.create_resource_structure(tmp_path)
+    lst_created_paths = create_resource_structure(tmp_path)
 
     assert lst_created_paths[0].is_dir()
     assert lst_created_paths[1].is_dir()
@@ -18,10 +18,10 @@ def test_returns_resource_structure_when_no_resources_exist(tmp_path):
 def test_returns_resource_structure_when_resources_exist(tmp_path):
     """Returns the paths to the resource and batch data folder with the next id."""
     # Create first resource structure
-    sp.create_resource_structure(tmp_path)
+    create_resource_structure(tmp_path)
 
     # Create new resource structure
-    lst_created_paths = sp.create_resource_structure(tmp_path)
+    lst_created_paths = create_resource_structure(tmp_path)
 
     assert lst_created_paths[0].is_dir()
     assert lst_created_paths[1].is_dir()
@@ -34,4 +34,4 @@ def test_returns_resource_structure_when_resources_exist(tmp_path):
 def test_raises_not_a_directory_error(tmp_path):
     """Raises NotADirectoryError when the path is not an existing directory."""
     with raises(NotADirectoryError):
-        sp.create_resource_structure(tmp_path / "non_existent_folder")
+        create_resource_structure(tmp_path / "non_existent_folder")


### PR DESCRIPTION
## Description

It bothers me to no end that Pythons built-in functionals are so user-unfriendly. So this is the start of some refactoring I will do, with simpler user-friendly versions of map that are inspired from the R package purrr, which implements and designs functionals so nicely. So these functionals are mostly a copy of what purrr has.

I will be adding other functionals here over time.

Closes #1267 

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
