### PR TITLE
feat: :sparkles: add simple `root()` method in `PackagePath`

### DIFF
--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -46,7 +46,7 @@ from urllib.request import urlretrieve
 
 temp_path = Path(mkdtemp())
 package_path = sp.PackagePath(temp_path / "diabetes-study")
-package_path.path.mkdir()
+package_path.root().mkdir()
 
 package_properties = sp.example_package_properties()
 sp.write_package_properties(
@@ -167,14 +167,14 @@ as a `PackagePath` object in the `package_path` variable. In this guide,
 the root folder of the package is in a temporary folder:
 
 ```{python}
-print(package_path.path)
+print(package_path.root())
 ```
 
 Let's take a look at the current files and folders in the data package:
 
 ```{python}
 #| echo: false
-print(list(package_path.path.glob("**/*")))
+print(list(package_path.root().glob("**/*")))
 ```
 
 This shows that the data package already includes a `datapackage.json`
@@ -185,7 +185,7 @@ directory. To point it to another location, pass it the path to your
 data package folder, like in the example below.
 
 ```{python}
-resource_path, _ = sp.create_resource_structure(path=package_path.path)
+resource_path, _ = sp.create_resource_structure(path=package_path.root())
 resource_properties = sp.create_resource_properties(
     path=resource_path,
     properties=resource_properties

--- a/src/seedcase_sprout/core/paths.py
+++ b/src/seedcase_sprout/core/paths.py
@@ -50,6 +50,10 @@ class PackagePath:
         """Set the base path."""
         self.path = path or Path.cwd()
 
+    def root(self) -> Path:
+        """Path to the root folder of the package."""
+        return self.path
+
     def properties(self) -> Path:
         """Path to the `datapackage.json` file."""
         return Path(self.path) / "datapackage.json"

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -26,6 +26,6 @@ def test_path_defaults_to_cwd_at_call_time(tmp_path):
     try:
         os.chdir(tmp_path)
         package_path = PackagePath()
-        assert package_path.path == tmp_path
+        assert package_path.root() == tmp_path
     finally:
         os.chdir(original_cwd)

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -9,6 +9,7 @@ def test_package_path_outputs_an_absolute_path(tmp_path):
     # Need to give the `tmp_path` to the class otherwise it uses the working directory
     # of the test script.
     path = PackagePath(tmp_path)
+    assert path.root().is_absolute()
     assert path.properties().is_absolute()
     assert path.readme().is_absolute()
     assert path.resources().is_absolute()


### PR DESCRIPTION
## Description

This PR adds a simple `root()` method in `PackagePath` to make accessing the root path use the same pattern as other paths.



<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
