### PR TITLE
feat: :sparkles: finish up `PackagePath` and `resource_batch_files()`

### DIFF
--- a/src/seedcase_sprout/core/paths.py
+++ b/src/seedcase_sprout/core/paths.py
@@ -28,7 +28,7 @@ class PackagePath:
             directory.
 
     Returns:
-        The absolute path to the data package's file or folder.
+        A `PackagePath` object representing the structure of a data package.
 
     Examples:
         ```{python}
@@ -56,15 +56,15 @@ class PackagePath:
 
     def properties(self) -> Path:
         """Path to the `datapackage.json` file."""
-        return Path(self.path) / "datapackage.json"
+        return self.root() / "datapackage.json"
 
     def readme(self) -> Path:
         """Path to the `README.md` file."""
-        return Path(self.path) / "README.md"
+        return self.root() / "README.md"
 
     def resources(self) -> Path:
         """Path to the `resources/` folder."""
-        return Path(self.path) / "resources"
+        return self.root() / "resources"
 
     def resource(self, resource_name: str) -> Path:
         """Path to the specified `resources/<name>/` folder.
@@ -73,7 +73,7 @@ class PackagePath:
             resource_name: The name of the resource. Use `ResourceProperties.name` to
                 get the correct resource name.
         """
-        return Path(self.path) / "resources" / str(resource_name)
+        return self.resources() / str(resource_name)
 
     def resource_data(self, resource_name: str) -> Path:
         """Path to the specific resource's data file.
@@ -82,7 +82,7 @@ class PackagePath:
             resource_name: The name of the resource. Use `ResourceProperties.name` to
                 get the correct resource name.
         """
-        return Path(self.path) / "resources" / str(resource_name) / "data.parquet"
+        return self.resource(resource_name) / "data.parquet"
 
     def resource_batch(self, resource_name: str) -> Path:
         """Path to the specific resource's `batch/` folder.
@@ -91,16 +91,14 @@ class PackagePath:
             resource_name: The name of the resource. Use `ResourceProperties.name` to
                 get the correct resource name.
         """
-        return Path(self.path) / "resources" / str(resource_name) / "batch"
+        return self.resource(resource_name) / "batch"
 
-    def resource_batch_files(self, resource_name: str) -> Path:
+    def resource_batch_files(self, resource_name: str) -> list[Path]:
         """Path to all the files in the specific resource's `batch/` folder.
 
         Args:
             resource_name: The name of the resource. Use `ResourceProperties.name` to
                 get the correct resource name.
         """
-        # TODO: This needs a check if the folder exists?
-        return list(
-            Path(Path(self.path) / "resources" / str(resource_name) / "batch").iterdir()
-        )
+        batch_folder = self.resource_batch(resource_name)
+        return list(batch_folder.iterdir()) if batch_folder.is_dir() else []

--- a/src/seedcase_sprout/core/paths.py
+++ b/src/seedcase_sprout/core/paths.py
@@ -94,7 +94,7 @@ class PackagePath:
         return self.resource(resource_name) / "batch"
 
     def resource_batch_files(self, resource_name: str) -> list[Path]:
-        """Path to all the files in the specific resource's `batch/` folder.
+        """Paths to all the files in the specific resource's `batch/` folder.
 
         Args:
             resource_name: The name of the resource. Use `ResourceProperties.name` to

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+
+from pytest import fixture
+
+
+@fixture
+def tmp_cwd(tmp_path):
+    """Temporarily changes the working directory to a temporary path.
+
+    This fixture changes the current working directory to a temporary one
+    (provided by pytest's `tmp_path`) for the duration of the test. After the
+    test finishes, the original working directory is restored.
+
+    Yields:
+        The temporary path that becomes the current working directory.
+
+    Examples:
+        ```{python}
+        def test_something(tmp_cwd):
+            # cwd is now a temporary directory
+            ...
+        ```
+    """
+    original = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(original)

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -14,7 +14,44 @@ def test_package_path_outputs_an_absolute_path(tmp_path):
     assert path.resource("test").is_absolute()
     assert path.resource_data("test").is_absolute()
     assert path.resource_batch("test").is_absolute()
-    # TODO: Test `resource_batch_files()` after deciding whether to do a check first?
+
+
+def test_methods_return_correct_path(tmp_path):
+    """Methods should return the expected path."""
+    package_path = PackagePath(tmp_path)
+    assert package_path.root() == tmp_path
+    assert package_path.properties() == tmp_path / "datapackage.json"
+    assert package_path.readme() == tmp_path / "README.md"
+    assert package_path.resources() == tmp_path / "resources"
+    assert package_path.resource("test") == tmp_path / "resources" / "test"
+    assert (
+        package_path.resource_data("test")
+        == tmp_path / "resources" / "test" / "data.parquet"
+    )
+
+    assert (
+        package_path.resource_batch("test") == tmp_path / "resources" / "test" / "batch"
+    )
+
+
+def test_resource_batch_files_returns_empty_list_when_no_batches(tmp_path):
+    """resource_batch_files() should return an empty list when no batches are found
+    for the resource."""
+    assert PackagePath(tmp_path).resource_batch_files("test") == []
+
+
+def test_resource_batch_files_returns_file_paths_when_batches(tmp_path):
+    """resource_batch_files() should return the file paths to the batch files of the
+    resource."""
+    package_path = PackagePath(tmp_path)
+    # Add batches for 2 resources
+    for file in ["test1", "test2"]:
+        batch_folder = package_path.resource_batch(file)
+        batch_folder.mkdir(parents=True)
+        (batch_folder / "file.txt").touch()
+
+    # Only the batch file for the given resource should be returned
+    assert package_path.resource_batch_files("test2") == [batch_folder / "file.txt"]
 
 
 def test_path_defaults_to_cwd_at_call_time(tmp_cwd):

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -1,5 +1,3 @@
-import os
-
 from seedcase_sprout.core import PackagePath
 
 
@@ -19,13 +17,8 @@ def test_package_path_outputs_an_absolute_path(tmp_path):
     # TODO: Test `resource_batch_files()` after deciding whether to do a check first?
 
 
-def test_path_defaults_to_cwd_at_call_time(tmp_path):
+def test_path_defaults_to_cwd_at_call_time(tmp_cwd):
     """When no root path is provided, the root path should default to the cwd of the
     calling script."""
-    original_cwd = os.getcwd()
-    try:
-        os.chdir(tmp_path)
-        package_path = PackagePath()
-        assert package_path.root() == tmp_path
-    finally:
-        os.chdir(original_cwd)
+    package_path = PackagePath()
+    assert package_path.root() == tmp_cwd


### PR DESCRIPTION
## Description

This PR finishes up `PackagePath`, especially `resource_batch_files()`. I made it not throw an error if there are no batch files for the resource because the other methods don't throw either. I think returning `[]` when there are no batch files is in keeping with the spirit of the class. But we can always change it!

I also did some general tidying.

This is groundwork for #1210

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
