### PR TITLE
feat: :sparkles: only return `.parquet` files in the batch folder

### DIFF
--- a/src/seedcase_sprout/core/paths.py
+++ b/src/seedcase_sprout/core/paths.py
@@ -100,5 +100,4 @@ class PackagePath:
             resource_name: The name of the resource. Use `ResourceProperties.name` to
                 get the correct resource name.
         """
-        batch_folder = self.resource_batch(resource_name)
-        return list(batch_folder.iterdir()) if batch_folder.is_dir() else []
+        return list(self.resource_batch(resource_name).glob("*.parquet"))

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -42,16 +42,17 @@ def test_resource_batch_files_returns_empty_list_when_no_batches(tmp_path):
 
 def test_resource_batch_files_returns_file_paths_when_batches(tmp_path):
     """resource_batch_files() should return the file paths to the batch files of the
-    resource."""
+    resource. Only Parquet files should be returned."""
     package_path = PackagePath(tmp_path)
     # Add batches for 2 resources
-    for file in ["test1", "test2"]:
-        batch_folder = package_path.resource_batch(file)
+    for resource in ["test1", "test2"]:
+        batch_folder = package_path.resource_batch(resource)
         batch_folder.mkdir(parents=True)
-        (batch_folder / "file.txt").touch()
+        (batch_folder / "sub-folder").mkdir()
+        [(batch_folder / file).touch() for file in ["file", "file.txt", "file.parquet"]]
 
     # Only the batch file for the given resource should be returned
-    assert package_path.resource_batch_files("test2") == [batch_folder / "file.txt"]
+    assert package_path.resource_batch_files("test2") == [batch_folder / "file.parquet"]
 
 
 def test_path_defaults_to_cwd_at_call_time(tmp_cwd):


### PR DESCRIPTION
## Description

This PR makes `resource_batch_files()` return only `.parquet` files.


<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
