### PR TITLE
refactor: :recycle: make master Frictionless - Polars type map

### DIFF
--- a/src/seedcase_sprout/core/check_data.py
+++ b/src/seedcase_sprout/core/check_data.py
@@ -1,14 +1,15 @@
-from typing import Callable
-
 import polars as pl
 
 from seedcase_sprout.core.check_properties import (
     check_resource_properties,
 )
 from seedcase_sprout.core.get_nested_attr import get_nested_attr
+from seedcase_sprout.core.map_data_types import (
+    _FRICTIONLESS_TO_POLARS,
+    _FRICTIONLESS_TO_POLARS_DESCRIPTION,
+)
 from seedcase_sprout.core.properties import (
     FieldProperties,
-    FieldType,
     ResourceProperties,
 )
 
@@ -171,7 +172,7 @@ def _not_allowed_type(polars_type: pl.DataType, field: FieldProperties) -> bool:
     Returns:
         True if the Polars type does not match the Frictionless type, False otherwise.
     """
-    is_allowed_type = _FRICTIONLESS_TO_POLARS_TYPE_CHECK[field.type or "any"]
+    is_allowed_type = _FRICTIONLESS_TO_POLARS[field.type or "any"]
     return not is_allowed_type(polars_type)
 
 
@@ -187,49 +188,8 @@ def _get_column_type_error(
     Returns:
         A `ValueError`.
     """
-    allowed_types = _FRICTIONLESS_TO_ALLOWED_POLARS_TYPES[field.type or "any"]
+    allowed_types = _FRICTIONLESS_TO_POLARS_DESCRIPTION[field.type or "any"]
     return ValueError(
         f"Expected type of column '{field.name}' "
         f"to be {allowed_types} but found '{polars_type}'."
     )
-
-
-# Mapping from Frictionless types to check functions for allowed Polars types
-_FRICTIONLESS_TO_POLARS_TYPE_CHECK: dict[FieldType, Callable[[pl.DataType], bool]] = {
-    "string": lambda dtype: isinstance(dtype, (pl.String, pl.Categorical, pl.Enum)),
-    "integer": lambda dtype: dtype.is_integer(),
-    "number": lambda dtype: dtype.is_float() or dtype.is_decimal(),
-    "year": lambda dtype: dtype.is_integer(),
-    "geopoint": lambda dtype: (
-        isinstance(dtype, pl.Array) and dtype.size == 2 and dtype.inner.is_numeric()
-    ),
-    "datetime": lambda dtype: dtype == pl.Datetime,
-    "date": lambda dtype: dtype == pl.Date,
-    "time": lambda dtype: dtype == pl.Time,
-    "yearmonth": lambda dtype: dtype == pl.Date,
-    "boolean": lambda dtype: dtype == pl.Boolean,
-    "duration": lambda dtype: dtype == pl.String,
-    "object": lambda dtype: dtype == pl.String,
-    "array": lambda dtype: dtype == pl.String,
-    "geojson": lambda dtype: dtype == pl.String,
-    "any": lambda _: True,
-}
-
-# Mapping from Frictionless types to descriptions of allowed Polars types
-_FRICTIONLESS_TO_ALLOWED_POLARS_TYPES: dict[FieldType, str] = {
-    "string": "a string, categorical, or enum type",
-    "integer": "an integer type",
-    "number": "a float or decimal type",
-    "year": "an integer type",
-    "geopoint": "an array of a numeric type with size 2",
-    "datetime": f"'{pl.Datetime}'",
-    "date": f"'{pl.Date}'",
-    "time": f"'{pl.Time}'",
-    "yearmonth": f"'{pl.Date}'",
-    "boolean": f"'{pl.Boolean}'",
-    "duration": f"'{pl.String}'",
-    "object": f"'{pl.String}'",
-    "array": f"'{pl.String}'",
-    "geojson": f"'{pl.String}'",
-    "any": "any type",
-}

--- a/src/seedcase_sprout/core/examples.py
+++ b/src/seedcase_sprout/core/examples.py
@@ -10,7 +10,6 @@ from seedcase_sprout.core.as_readme_text import as_readme_text
 from seedcase_sprout.core.create_resource_properties import create_resource_properties
 from seedcase_sprout.core.create_resource_structure import create_resource_structure
 from seedcase_sprout.core.get_iso_timestamp import get_iso_timestamp
-from seedcase_sprout.core.map_data_types import FRICTIONLESS_TO_POLARS
 from seedcase_sprout.core.paths import PackagePath
 from seedcase_sprout.core.properties import (
     ContributorProperties,
@@ -211,7 +210,7 @@ def example_data_all_types() -> pl.DataFrame:
                 ["15:00:59", "00:00:00.3", "12:00:00.345345"]
             ).str.to_time(),
             "my_geopoint": pl.Series([[-90, -180], [5, 45], [5.9999, 45.0000]]).cast(
-                FRICTIONLESS_TO_POLARS["geopoint"]
+                pl.Array(pl.Float64, 2)
             ),
             "my_array": [
                 "[]",

--- a/src/seedcase_sprout/core/map_data_types.py
+++ b/src/seedcase_sprout/core/map_data_types.py
@@ -94,6 +94,7 @@ def _get_allowed_polars_types(
         # added directly to the error message instead.
         return [pl.Array]
 
+    # TODO: Revise once `_map_keep()` has been implemented
     return [
         polars_type
         for polars_type, datapackage_types in _POLARS_TO_DATAPACKAGE.items()

--- a/src/seedcase_sprout/core/map_data_types.py
+++ b/src/seedcase_sprout/core/map_data_types.py
@@ -1,24 +1,101 @@
+from collections import OrderedDict
+from typing import Callable
+
 import polars as pl
 
 from seedcase_sprout.core.properties import FieldType
 
-# Mapping from Frictionless data types to Polars data types.
-# See https://sprout.seedcase-project.org/docs/design/interface/data-types
-# for more information.
-FRICTIONLESS_TO_POLARS: dict[FieldType, pl.DataType] = {
-    "string": pl.String,
-    "boolean": pl.Boolean,
-    "integer": pl.Int64,
-    "number": pl.Float64,
-    "year": pl.Int32,
-    "datetime": pl.Datetime,
-    "date": pl.Date,
-    "time": pl.Time,
-    "yearmonth": pl.Date,
-    "geopoint": pl.Array(pl.Float64, 2),
-    "duration": pl.String,
-    "object": pl.String,
-    "array": pl.String,
-    "geojson": pl.String,
-    "any": pl.String,
+"""
+Mapping between Frictionless types and Polars types.
+
+Each Frictionless type maps to a function that checks if a given Polars type is an
+allowed representation of that Frictionless type. There are often multiple allowed
+Polars types for a single Frictionless type.
+
+To allow reverse lookups, i.e. mapping a Polars type to a single Frictionless type,
+entries are listed in order of precedence. The Polars type should be compared against
+Frictionless types in the order they are listed. The first entry with a passing check
+should determine the Frictionless type. Use `polars_to_frictionless()` to do the reverse
+lookup.
+"""
+_FRICTIONLESS_TO_POLARS: OrderedDict[FieldType, Callable[[pl.DataType], bool]] = (
+    OrderedDict(
+        {
+            # Primary types: reverse lookup always gives back Frictionless type
+            "number": lambda dtype: dtype.is_float() or dtype.is_decimal(),
+            "integer": lambda dtype: (
+                dtype.is_integer() or isinstance(dtype, pl.Duration)
+            ),
+            "string": lambda dtype: isinstance(
+                dtype, (pl.String, pl.Categorical, pl.Enum, pl.Binary)
+            ),
+            "date": lambda dtype: isinstance(dtype, pl.Date),
+            "datetime": lambda dtype: isinstance(dtype, pl.Datetime),
+            "time": lambda dtype: dtype == pl.Time,  # Polars stores Time as a class
+            "boolean": lambda dtype: isinstance(dtype, pl.Boolean),
+            # Secondary types: reverse lookup gives back Frictionless type only if
+            # primary type doesn't take precedence
+            "array": lambda dtype: isinstance(dtype, (pl.String, pl.Array, pl.List)),
+            "object": lambda dtype: isinstance(
+                dtype, (pl.String, pl.Struct, pl.Object)
+            ),
+            # Tertiary types: reverse lookup never gives back Frictionless type
+            "geopoint": lambda dtype: (
+                isinstance(dtype, pl.Array)
+                and dtype.size == 2
+                and dtype.inner.is_numeric()
+            ),
+            "geojson": lambda dtype: isinstance(
+                dtype, (pl.String, pl.Struct, pl.Object)
+            ),
+            "year": lambda dtype: dtype.is_integer(),
+            "yearmonth": lambda dtype: isinstance(dtype, pl.Date),
+            "duration": lambda dtype: isinstance(dtype, pl.String),
+            # Fallback type
+            "any": lambda _: True,
+        }
+    )
+)
+
+# Mapping from Frictionless types to descriptions of allowed Polars types
+_FRICTIONLESS_TO_POLARS_DESCRIPTION: dict[FieldType, str] = {
+    "number": "a float or decimal type",
+    "integer": f"an integer type or '{pl.Duration}'",
+    "string": (
+        f"one of '{pl.String}', '{pl.Categorical}', '{pl.Enum}', or '{pl.Binary}'"
+    ),
+    "date": f"'{pl.Date}'",
+    "datetime": f"'{pl.Datetime}'",
+    "time": f"'{pl.Time}'",
+    "boolean": f"'{pl.Boolean}'",
+    "array": f"one of '{pl.String}', '{pl.Array}', or '{pl.List}'",
+    "object": f"one of '{pl.String}', '{pl.Struct}', or '{pl.Object}'",
+    "geopoint": "an array of a numeric type with size 2",
+    "geojson": f"one of '{pl.String}', '{pl.Struct}', or '{pl.Object}'",
+    "year": "an integer type",
+    "yearmonth": f"'{pl.Date}'",
+    "duration": f"'{pl.String}'",
+    "any": "any type",
 }
+
+
+def _polars_to_frictionless(dtype: pl.DataType) -> FieldType:
+    """Map a Polars type to the corresponding Frictionless type.
+
+    Frictionless types are matched against the Polars type in the order set out in
+    `_FRICTIONLESS_TO_POLARS_TYPE_CHECK`. The first successful match is returned.
+
+    Args:
+        dtype: The Polars type.
+
+    Returns:
+        The corresponding Frictionless type.
+    """
+    return next(
+        (
+            frictionless_type
+            for frictionless_type, is_type in _FRICTIONLESS_TO_POLARS.items()
+            if is_type(dtype)
+        ),
+        "any",
+    )

--- a/src/seedcase_sprout/core/map_data_types.py
+++ b/src/seedcase_sprout/core/map_data_types.py
@@ -7,7 +7,7 @@ Mapping between Polars types and Data Package types.
 
 Each Polars type can be described by any of the specified Data Package types.
 When extracting Data Package types from a data frame, each Polars type is mapped to
-the first Data Package type in the corresponding entry. 
+the first Data Package type in the corresponding entry.
 """
 _POLARS_TO_DATAPACKAGE: dict[type[pl.DataType], list[FieldType]] = {
     pl.Int8: ["integer", "year", "any"],

--- a/src/seedcase_sprout/core/map_data_types.py
+++ b/src/seedcase_sprout/core/map_data_types.py
@@ -83,7 +83,7 @@ def _polars_to_frictionless(dtype: pl.DataType) -> FieldType:
     """Map a Polars type to the corresponding Frictionless type.
 
     Frictionless types are matched against the Polars type in the order set out in
-    `_FRICTIONLESS_TO_POLARS_TYPE_CHECK`. The first successful match is returned.
+    `_FRICTIONLESS_TO_POLARS`. The first successful match is returned.
 
     Args:
         dtype: The Polars type.

--- a/src/seedcase_sprout/core/map_data_types.py
+++ b/src/seedcase_sprout/core/map_data_types.py
@@ -72,7 +72,6 @@ def _polars_and_datapackage_types_match(
 
     Returns:
         Whether the given types match.
-
     """
     return (datapackage_type or "any") in _get_allowed_datapackage_types(polars_type)
 

--- a/tests/core/sprout_checks/test_check_data.py
+++ b/tests/core/sprout_checks/test_check_data.py
@@ -10,7 +10,7 @@ from seedcase_sprout.core.examples import (
     example_data,
     example_resource_properties,
 )
-from seedcase_sprout.core.map_data_types import _FRICTIONLESS_TO_POLARS_DESCRIPTION
+from seedcase_sprout.core.map_data_types import _get_allowed_polars_types
 from seedcase_sprout.core.properties import (
     FieldProperties,
     ResourceProperties,
@@ -153,10 +153,8 @@ def test_rejects_incorrect_column_type(frictionless_type, resource_properties):
     errors = error_info.value.exceptions
     assert len(errors) == 1
     polars_type = re.escape(str(data.schema.dtypes()[0]))
-    allowed_types = _FRICTIONLESS_TO_POLARS_DESCRIPTION[frictionless_type]
-    assert re.search(
-        rf"'my_col'.*{allowed_types}.*found '{polars_type}'", str(errors[0])
-    )
+    allowed_types = _get_allowed_polars_types(frictionless_type)
+    assert re.search(rf"'my_col'.*{allowed_types}.*found {polars_type}", str(errors[0]))
 
 
 def test_rejects_multiple_incorrect_column_types():
@@ -172,9 +170,9 @@ def test_rejects_multiple_incorrect_column_types():
     assert len(errors) == data.width
     for error, field in zip(errors, resource_properties.schema.fields):
         polars_type = re.escape(str(data.schema[field.name]))
-        allowed_types = _FRICTIONLESS_TO_POLARS_DESCRIPTION[field.type]
+        allowed_types = _get_allowed_polars_types(field.type)
         assert re.search(
-            rf"'{field.name}'.*{allowed_types}.*found '{polars_type}'", str(error)
+            rf"'{field.name}'.*{allowed_types}.*found {polars_type}", str(error)
         )
 
 

--- a/tests/core/sprout_checks/test_check_data.py
+++ b/tests/core/sprout_checks/test_check_data.py
@@ -5,16 +5,12 @@ import polars as pl
 from polars.testing import assert_frame_equal
 from pytest import fixture, mark, raises
 
-from seedcase_sprout.core.check_data import (
-    _FRICTIONLESS_TO_ALLOWED_POLARS_TYPES,
-    check_data,
-)
+from seedcase_sprout.core.check_data import check_data
 from seedcase_sprout.core.examples import (
     example_data,
-    example_data_all_types,
     example_resource_properties,
-    example_resource_properties_all_types,
 )
+from seedcase_sprout.core.map_data_types import _FRICTIONLESS_TO_POLARS_DESCRIPTION
 from seedcase_sprout.core.properties import (
     FieldProperties,
     ResourceProperties,
@@ -41,44 +37,41 @@ def resource_properties() -> ResourceProperties:
     )
 
 
-def test_accepts_correct_columns():
+@mark.parametrize(
+    "fr_type, pl_types",
+    [
+        ("number", [pl.Float32, pl.Float64, pl.Decimal]),
+        ("integer", [pl.Int16, pl.UInt8, pl.Duration]),
+        ("string", [pl.String, pl.Categorical, pl.Enum(["A"]), pl.Binary]),
+        ("date", [pl.Date]),
+        ("datetime", [pl.Datetime]),
+        ("time", [pl.Time]),
+        ("boolean", [pl.Boolean]),
+        ("array", [pl.String, pl.Array, pl.List]),
+        ("object", [pl.String, pl.Struct, pl.Object]),
+        (
+            "geopoint",
+            [pl.Array(pl.Int128, 2), pl.Array(pl.Float32, 2), pl.Array(pl.Decimal, 2)],
+        ),
+        ("geojson", [pl.String, pl.Struct, pl.Object]),
+        ("year", [pl.Int32, pl.UInt8, pl.Int64]),
+        ("yearmonth", [pl.Date]),
+        ("duration", [pl.String]),
+        ("any", [pl.Unknown, pl.Null, pl.Object, pl.Int128, pl.Boolean]),
+    ],
+)
+def test_accepts_correct_columns(fr_type, pl_types):
     """Should not raise an error when columns in the data match columns in the
     resource properties."""
-    resource_properties = example_resource_properties_all_types()
-    resource_properties.schema.fields += [
-        FieldProperties(name="my_categorical", type="string"),
-        FieldProperties(name="my_enum", type="string"),
-        FieldProperties(name="my_int8", type="integer"),
-        FieldProperties(name="my_int8_year", type="year"),
-        FieldProperties(name="my_uint64", type="integer"),
-        FieldProperties(name="my_float32", type="number"),
-        FieldProperties(name="my_decimal", type="number"),
-        FieldProperties(name="my_int_geopoint", type="geopoint"),
+    resource_properties = example_resource_properties()
+    resource_properties.schema.fields = [
+        FieldProperties(name=str(pl_type), type=fr_type) for pl_type in pl_types
     ]
-    data = example_data_all_types().with_columns(
-        [
-            pl.Series(
-                "my_categorical", ["low", "medium", "high"], dtype=pl.Categorical
-            ),
-            pl.Series(
-                "my_enum",
-                ["low", "low", "high"],
-                dtype=pl.Enum(["low", "medium", "high"]),
-            ),
-            pl.Series("my_int8", [1, 22, 33], dtype=pl.Int8),
-            pl.Series("my_int8_year", [1, 22, 33], dtype=pl.Int8),
-            pl.Series("my_uint64", [1, 22, 33], dtype=pl.UInt64),
-            pl.Series("my_float32", [1.1, 2.2, 3.3], dtype=pl.Float32),
-            pl.Series("my_decimal", ["1.20", "2.56", "3.39"], dtype=pl.Decimal),
-            pl.Series(
-                "my_int_geopoint",
-                [[3, 4], [5, 45], [12, -4]],
-                dtype=pl.Array(pl.Int16, 2),
-            ),
-        ]
+    data = pl.DataFrame(
+        {str(pl_type): pl.Series([], dtype=pl_type) for pl_type in pl_types}
     )
 
-    assert_frame_equal(check_data(data, resource_properties), data)
+    assert check_data(data, resource_properties) is data
 
 
 def test_accepts_columns_in_any_order():
@@ -147,10 +140,9 @@ def test_throws_error_when_data_has_extra_and_missing_columns(resource_propertie
         "geojson",
     ],
 )
-def test_rejects_incorrect_column_type(frictionless_type):
+def test_rejects_incorrect_column_type(frictionless_type, resource_properties):
     """Should raise an error if the Polars type does not match the Frictionless type."""
-    data = pl.DataFrame({"my_col": pl.Series([{"prop": "value"}] * 3, dtype=pl.Object)})
-    resource_properties = example_resource_properties()
+    data = pl.DataFrame({"my_col": pl.Series([], dtype=pl.Null)})
     resource_properties.schema.fields = [
         FieldProperties(name="my_col", type=frictionless_type)
     ]
@@ -161,7 +153,7 @@ def test_rejects_incorrect_column_type(frictionless_type):
     errors = error_info.value.exceptions
     assert len(errors) == 1
     polars_type = re.escape(str(data.schema.dtypes()[0]))
-    allowed_types = _FRICTIONLESS_TO_ALLOWED_POLARS_TYPES[frictionless_type]
+    allowed_types = _FRICTIONLESS_TO_POLARS_DESCRIPTION[frictionless_type]
     assert re.search(
         rf"'my_col'.*{allowed_types}.*found '{polars_type}'", str(errors[0])
     )
@@ -180,7 +172,7 @@ def test_rejects_multiple_incorrect_column_types():
     assert len(errors) == data.width
     for error, field in zip(errors, resource_properties.schema.fields):
         polars_type = re.escape(str(data.schema[field.name]))
-        allowed_types = _FRICTIONLESS_TO_ALLOWED_POLARS_TYPES[field.type]
+        allowed_types = _FRICTIONLESS_TO_POLARS_DESCRIPTION[field.type]
         assert re.search(
             rf"'{field.name}'.*{allowed_types}.*found '{polars_type}'", str(error)
         )


### PR DESCRIPTION
## Description

This PR tidies up the Frictionless - Polars type maps:
- Removes the old `FRICTIONLESS_TO_POLARS`. This may be useful in e.g. shears, but no longer necessary in Sprout.
- Updates and renames `_FRICTIONLESS_TO_POLARS_TYPE_CHECK`. This is the master map. Updated with Signe's insights from #1264 .
- Adds a short function `_polars_to_frictionless()` to get the reverse mappings from the master map. This replaces `POLARS_TO_FRICTIONLESS` in #1264 .

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
