### PR TITLE
build: :hammer: add auto-spell checker

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,9 @@
+[files]
+extend-exclude = [
+  "*.json",
+  "*.css",
+  ".quarto/*",
+  "_site/*",
+  "_extensions/*",
+  ".coverage-report/*"
+]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,22 +1,17 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-  // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
     "donjayamanne.githistory",
     "felipecaputo.git-project-manager",
     "GitHub.vscode-pull-request-github",
-    "ms-azuretools.vscode-docker",
     "ms-python.python",
     "ms-python.vscode-pylance",
     "njpwerner.autodocstring",
     "quarto.quarto",
     "ms-toolsai.jupyter",
-    "streetsidesoftware.code-spell-checker",
     "vivaxy.vscode-conventional-commits",
     "charliermarsh.ruff",
     "pshaddel.conventional-branch",
-    "yy0931.vscode-sqlite3-editor"
+    "tekumara.typos-vscode"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,10 +32,6 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.languageServer": "Pylance",
   "files.insertFinalNewline": true,
-  "cSpell.enabledFileTypes": {
-    "quarto": true
-  },
-  "cSpell.language": "en,en-GB",
   "python.testing.pytestEnabled": true,
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
 }

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
     just --list --unsorted
 
 # Run all build-related recipes in the justfile
-run-all: install-deps format-python check-python test-python check-security check-commits build-website
+run-all: install-deps format-python check-python test-python check-security check-spelling check-commits build-website
 
 # Install Python package dependencies
 install-deps:
@@ -50,3 +50,7 @@ check-commits:
 # Run basic security checks on the package
 check-security:
   uv run bandit -r src/
+
+# Check for spelling errors in files
+check-spelling:
+  uv run typos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "quartodoc>=0.9.1",
     "ruff>=0.11.4",
     "time-machine>=2.16.0",
+    "typos>=1.31.1",
 ]
 
 [build-system]

--- a/tools/generated_properties_.py
+++ b/tools/generated_properties_.py
@@ -77,7 +77,7 @@ class TableDialectProperties:
         header_join (str | None):
         comment_rows (list[int] | None):
         comment_char (str | None): Specifies that any row beginning with this
-            one-character string, without preceeding whitespace, causes the entire
+            one-character string, without preceding whitespace, causes the entire
             line to be ignored.
         delimiter (str | None): A character sequence to use as the field
             separator.

--- a/uv.lock
+++ b/uv.lock
@@ -2159,6 +2159,7 @@ dev = [
     { name = "quartodoc" },
     { name = "ruff" },
     { name = "time-machine" },
+    { name = "typos" },
 ]
 
 [package.metadata]
@@ -2184,6 +2185,7 @@ dev = [
     { name = "quartodoc", specifier = ">=0.9.1" },
     { name = "ruff", specifier = ">=0.11.4" },
     { name = "time-machine", specifier = ">=2.16.0" },
+    { name = "typos", specifier = ">=1.31.1" },
 ]
 
 [[package]]
@@ -2468,6 +2470,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]
+
+[[package]]
+name = "typos"
+version = "1.31.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a5/e6e7b2debda93cb68430bae67297d82fdf8a0e06a4ac5ae590f9844fb91b/typos-1.31.1.tar.gz", hash = "sha256:089e2f0a266f00214c2b4726dd3947c904c978937c0635ce38134103d1a171b9", size = 1499507 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/0e/156a6411986d5d4e7c48f0a740db17628f777851337b45c4a4a164842a66/typos-1.31.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:03187da0c68e0613e6d743b1e5aa48a1a0b02bdfe8bfda8ed785927931713d64", size = 3127222 },
+    { url = "https://files.pythonhosted.org/packages/77/f1/d0e4af5636f9bac8996a1fbc6b498d6392c112df16d8e650d110be4d9d34/typos-1.31.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f19c54bab4ec5cf6912e50dda5f2edc0d31014f7788baddcdae830f6bfd73341", size = 3008343 },
+    { url = "https://files.pythonhosted.org/packages/93/0e/8f4bc7fe8947b70565cd6dd9e66ac5c4fd04014761212d4231a87a958d2f/typos-1.31.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57e4fb7f00e60408b00989d7c57ed81ebaf56a14bafbb75c003dbb82b0b5b74", size = 7589311 },
+    { url = "https://files.pythonhosted.org/packages/d8/80/04ba90f53e607babc85aea3cf366b5ceadf8c55ad34b678b5065adc94a7e/typos-1.31.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ddc6aa57710881e1a2e9998f3efd47f454b23ab60765f507bba277d0bb8686f", size = 6779237 },
+    { url = "https://files.pythonhosted.org/packages/1b/f8/5aa0bde621e20c1b3e524f8103106a64cc00e8c6de22041f32a7f7adb946/typos-1.31.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6641a3231b29edbac1a35394b0822bc218bd8f70caea233b90e382cbeb58731f", size = 7485234 },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/0f7ae6aea34990e4fca989903d0818c9f2c866559156acfb66c752cad921/typos-1.31.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1bc524b335d637f6c1b78b5396b997aa9c9ac7ed0361686209f5b88525fbb248", size = 6712666 },
+    { url = "https://files.pythonhosted.org/packages/20/25/812861c0f7895e35e307a2a6a2a63869e0c57af4c5d3f790f7eec569669d/typos-1.31.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bd5031c8a8480640328c2cc2c4defc54471feeaae8201aefff94e16b6ca87f22", size = 7576357 },
+    { url = "https://files.pythonhosted.org/packages/ce/23/7e71bfcf40978eb2595c959bc8222c4350a30280c15d78c68a89dd57a188/typos-1.31.1-py3-none-win32.whl", hash = "sha256:07cf79739059c4f74e0c02a5e1c80b9adf70797a76ea4a4ebab3fce134935d60", size = 2749337 },
+    { url = "https://files.pythonhosted.org/packages/45/93/a7c3af7cf52e24d55fbd6fe6e43068ab2bd7647dc9a8a3e813f5247fec5e/typos-1.31.1-py3-none-win_amd64.whl", hash = "sha256:2a0c3a46894aa8e5f2dddd240439c8f537e5b3b084f37fd127dfdb0494f3ccf2", size = 2899374 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Found a super nifty Rust package (with Python package) that does spell checking.

Removed use of cSpell as well, since it isn't needed anymore.

This will be included in the GitHub action shortly.

Closes #1221

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
