### PR TITLE
fix: :bug: do not escape non-ASCII characters when writing JSON

### DIFF
--- a/src/seedcase_sprout/core/internals/write.py
+++ b/src/seedcase_sprout/core/internals/write.py
@@ -18,4 +18,4 @@ def _write_json(json_object: list | dict, path: Path) -> Path:
         FileNotFoundError: If the parent folder of the file doesn't exist.
         TypeError: If the object is not JSON serialisable.
     """
-    return write_file(json.dumps(json_object, indent=2), path)
+    return write_file(json.dumps(json_object, indent=2, ensure_ascii=False), path)

--- a/tests/core/test_write_package_properties.py
+++ b/tests/core/test_write_package_properties.py
@@ -82,6 +82,17 @@ def test_writes_properties_with_missing_resources(path, package_properties):
     assert_file_contains(path, new_properties)
 
 
+def test_writes_properties_using_utf8(path, package_properties):
+    """Should write properties to file using UTF-8."""
+    package_properties.description = (
+        "Håkan Ørsted's favourite letters: æ ø å Æ Ø Å é μῆνιν ἄειδε θεὰ"
+    )
+
+    write_package_properties(package_properties, path)
+
+    assert package_properties.description in path.read_bytes().decode("utf-8")
+
+
 def test_throws_error_if_error_in_package_properties(path, package_properties):
     """Should throw `CheckError`s if there are errors in the package properties."""
     package_properties.name = "invalid name with spaces"


### PR DESCRIPTION
## Description

This PR fixes the encoding of special characters. Turns out `json.dumps` automatically escapes non-ASCII characters, which we don't want, we want to have them as UTF-8 (the default). This was pointed out by Kris a long time ago.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
