### PR TITLE
fix: :bug: raise a more informative error when the data list is empty

### DIFF
--- a/src/seedcase_sprout/core/join_resource_batches.py
+++ b/src/seedcase_sprout/core/join_resource_batches.py
@@ -40,6 +40,7 @@ def join_resource_batches(
             observational units removed.
 
     Raises:
+        ValueError: If an empty `data_list` is provided.
         polars.exceptions.ShapeError: Raised when dataframes in data_list have different
             shapes, such as mismatched column names or numbers.
 
@@ -61,6 +62,13 @@ def join_resource_batches(
         ```
     """
     check_resource_properties(resource_properties)
+
+    if data_list == []:
+        raise ValueError(
+            "Could not join resource batches because an empty `data_list` was "
+            f"provided. The batch folder for the resource '{resource_properties.name}' "
+            "may be empty."
+        )
 
     data = pl.concat(data_list)
     primary_key = resource_properties.schema.primary_key

--- a/tests/core/test_join_resource_batches.py
+++ b/tests/core/test_join_resource_batches.py
@@ -222,3 +222,11 @@ def test_single_dataframe_in_data_list(data_list, resource_properties):
     # Then
     expected_joined_batches = data_list[0].drop(BATCH_TIMESTAMP_COLUMN_NAME)
     assert_frame_equal(joined_batches, expected_joined_batches, check_row_order=False)
+
+
+def test_throws_error_with_empty_data_list(resource_properties):
+    """Should throw an informative error if an empty data list is provided."""
+    with raises(ValueError) as error:
+        join_resource_batches([], resource_properties)
+
+    assert resource_properties.name in str(error)


### PR DESCRIPTION
## Description

This PR makes `join_resource_batches` raise an error explicitly and with an informative error message when the input data list is empty. Otherwise `pl.concat` will throw an error saying "cannot concat empty list".

This happens realistically when the batch files are loaded using `batches = sp.read_resource_batches(resource_properties)`, but there aren't any batch files. I just happened to run into this when running a version of the resource guide.

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
