### PR TITLE
fix: :bug: resolve temp paths so tests pass on MacOS as well

### DIFF
--- a/tests/core/test_examples.py
+++ b/tests/core/test_examples.py
@@ -85,7 +85,9 @@ def test_changes_cwd_to_package_root_in_package_context():
     After exiting the context, the cwd should be reset to the original location."""
     original_cwd = Path.cwd()
     with ExamplePackage() as package_path:
-        assert Path.cwd() == package_path.path
+        # Resolve paths to ensure symlinks are compared correctly on MacOS as well
+        # (i.e., `/var` -> `/private/var` on MacOS)
+        assert Path.cwd().resolve() == package_path.path.resolve()
 
     assert Path.cwd() == original_cwd
 

--- a/tests/core/test_write_resource_data.py
+++ b/tests/core/test_write_resource_data.py
@@ -21,18 +21,20 @@ def test_writes_data_to_correct_location():
     with ExamplePackage() as package_path:
         resource_properties = read_properties().resources[0]
         data = example_data()
-        expected_path = package_path.resource_data(resource_properties.name)
+        # Resolve paths to ensure symlinks are compared correctly on MacOS as well
+        # (i.e., `/var` -> `/private/var` on MacOS)
+        expected_path = package_path.resource_data(resource_properties.name).resolve()
 
         # With custom path
         data_path = write_resource_data(data, resource_properties, package_path.root())
 
-        assert data_path == expected_path
+        assert data_path.resolve() == expected_path
         assert_frame_equal(pl.read_parquet(data_path), data)
 
         # With default path
         data_path = write_resource_data(data, resource_properties)
 
-        assert data_path == expected_path
+        assert data_path.resolve() == expected_path
         assert_frame_equal(pl.read_parquet(data_path), data)
 
 


### PR DESCRIPTION
## Description

Two tests were failing for me locally and it seems to be bc of how MacOS uses `/var` as a symlink to `/private/var` (thanks @martonvago 🌟 ). 
So, these two tests were failing bc the paths are compared directly and even though they refer to the same location, the paths aren’t identical. I solved this by resolving the paths with `.resolve()`. 

A different solution could be to change how we assert the paths. Like `assert Path.cwd().samefile(package_path.path)`. 

Thoughts?

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [X] Added or updated tests
- [X] Ran `just run-all`
