### PR TITLE
build: ➕ add `vulture` to `dev` with `just` recipe to check for unused code

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,8 +59,8 @@ check-spelling:
 check-unused:
   # exit code=0: No unused code was found
   # exit code=3: Unused code was found
-  # Three confidence values: 
+  # Three confidence values:
   # - 100 %: function/method/class argument, unreachable code
-  # - 90 %: import 
+  # - 90 %: import
   # - 60 %: attribute, class, function, method, property, variable
   vulture src/ tests/

--- a/justfile
+++ b/justfile
@@ -54,3 +54,13 @@ check-security:
 # Check for spelling errors in files
 check-spelling:
   uv run typos
+
+# Check for unused code in the package and its tests
+check-unused:
+  # exit code=0: No unused code was found
+  # exit code=3: Unused code was found
+  # Three confidence values: 
+  # - 100 %: function/method/class argument, unreachable code
+  # - 90 %: import 
+  # - 60 %: attribute, class, function, method, property, variable
+  vulture src/ tests/

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
     just --list --unsorted
 
 # Run all build-related recipes in the justfile
-run-all: install-deps format-python check-python test-python check-security check-spelling check-commits build-website
+run-all: install-deps format-python check-python test-python check-security check-spelling check-commits build-website check-unused
 
 # Install Python package dependencies
 install-deps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "ruff>=0.11.4",
     "time-machine>=2.16.0",
     "typos>=1.31.1",
+    "vulture>=2.14",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -2160,6 +2160,7 @@ dev = [
     { name = "ruff" },
     { name = "time-machine" },
     { name = "typos" },
+    { name = "vulture" },
 ]
 
 [package.metadata]
@@ -2186,6 +2187,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11.4" },
     { name = "time-machine", specifier = ">=2.16.0" },
     { name = "typos", specifier = ">=1.31.1" },
+    { name = "vulture", specifier = ">=2.14" },
 ]
 
 [[package]]
@@ -2537,6 +2539,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/e0/633e369b91bbc664df47dcb5454b6c7cf441e8f5b9d0c250ce9f0546401e/virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8", size = 4346945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/ed/3cfeb48175f0671ec430ede81f628f9fb2b1084c9064ca67ebe8c0ed6a05/virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6", size = 4329461 },
+]
+
+[[package]]
+name = "vulture"
+version = "2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR adds `vulture` to our `dev` dependencies and a `just` recipe that uses vulture to check for unused code in the `src/` and `tests/` directories. 

The `check-unused` recipe is also added to `run-all`.

I thought it made sense to the check for unused code add it as a `just recipe` instead of e.g., a workflow, but let me know if you agree or not :grin: 

Closes #1223 

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.

## Checklist

- [X] Ran `just run-all`
