### PR TITLE
refactor: :recycle: simplify and move into internals

### DIFF
--- a/src/seedcase_sprout/internals/__init__.py
+++ b/src/seedcase_sprout/internals/__init__.py
@@ -1,6 +1,7 @@
 """Internal functions for the package."""
 
 from .check import _check_is_dir, _check_is_file
+from .create import _create_relative_resource_data_path
 from .functionals import _map, _map2
 from .get import _get_iso_timestamp
 from .read import _read_json
@@ -9,6 +10,7 @@ from .write import _write_json
 __all__ = [
     "_check_is_file",
     "_check_is_dir",
+    "_create_relative_resource_data_path",
     "_get_iso_timestamp",
     "_map",
     "_map2",

--- a/src/seedcase_sprout/internals/__init__.py
+++ b/src/seedcase_sprout/internals/__init__.py
@@ -1,7 +1,7 @@
 """Internal functions for the package."""
 
 from .check import _check_is_dir, _check_is_file
-from .create import _create_relative_resource_data_path
+from .create import _create_resource_data_path
 from .functionals import _map, _map2
 from .get import _get_iso_timestamp
 from .read import _read_json
@@ -10,7 +10,7 @@ from .write import _write_json
 __all__ = [
     "_check_is_file",
     "_check_is_dir",
-    "_create_relative_resource_data_path",
+    "_create_resource_data_path",
     "_get_iso_timestamp",
     "_map",
     "_map2",

--- a/src/seedcase_sprout/internals/create.py
+++ b/src/seedcase_sprout/internals/create.py
@@ -1,15 +1,9 @@
 from pathlib import Path
 from typing import Any
 
-from seedcase_sprout.sprout_checks.is_resource_name_correct import (
-    _is_resource_name_correct,
-)
-
 
 def _create_relative_resource_data_path(resource_name: Any) -> str | None:
     """Creates a stringified relative path to the resource data file based on the name.
-
-    The path is created only if the resource name is correct.
 
     Args:
         resource_name: The name of the resource.
@@ -18,8 +12,4 @@ def _create_relative_resource_data_path(resource_name: Any) -> str | None:
         The relative path from the package root to the resource data file.
             E.g., "resources/test-resource/data.parquet"
     """
-    return (
-        str(Path("resources", resource_name, "data.parquet"))
-        if _is_resource_name_correct(resource_name)
-        else None
-    )
+    return str(Path("resources", resource_name, "data.parquet"))

--- a/src/seedcase_sprout/internals/create.py
+++ b/src/seedcase_sprout/internals/create.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 
-def _create_relative_resource_data_path(resource_name: Any) -> str | None:
+def _create_resource_data_path(resource_name: Any) -> str:
     """Creates a stringified relative path to the resource data file based on the name.
 
     Args:

--- a/src/seedcase_sprout/internals/create.py
+++ b/src/seedcase_sprout/internals/create.py
@@ -1,8 +1,7 @@
 from pathlib import Path
-from typing import Any
 
 
-def _create_resource_data_path(resource_name: Any) -> str:
+def _create_resource_data_path(resource_name: str) -> str:
     """Creates a stringified relative path to the resource data file based on the name.
 
     Args:

--- a/src/seedcase_sprout/properties.py
+++ b/src/seedcase_sprout/properties.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 from dacite import from_dict
 
 from seedcase_sprout.internals import (
-    _create_relative_resource_data_path,
+    _create_resource_data_path,
     _get_iso_timestamp,
 )
 from seedcase_sprout.sprout_checks.is_resource_name_correct import (
@@ -399,8 +399,11 @@ class ResourceProperties(Properties):
 
     def __post_init__(self):
         """Generates the path from the resource name after object creation."""
-        if _is_resource_name_correct(self.name):
-            self.path = _create_relative_resource_data_path(self.name)
+        self.path = (
+            _create_resource_data_path(self.name)
+            if _is_resource_name_correct(self.name)
+            else None
+        )
 
 
 @dataclass

--- a/src/seedcase_sprout/properties.py
+++ b/src/seedcase_sprout/properties.py
@@ -15,9 +15,12 @@ from uuid import uuid4
 
 from dacite import from_dict
 
-from seedcase_sprout.internals import _get_iso_timestamp
-from seedcase_sprout.internals._create_relative_resource_data_path import (
+from seedcase_sprout.internals import (
     _create_relative_resource_data_path,
+    _get_iso_timestamp,
+)
+from seedcase_sprout.sprout_checks.is_resource_name_correct import (
+    _is_resource_name_correct,
 )
 
 
@@ -396,7 +399,8 @@ class ResourceProperties(Properties):
 
     def __post_init__(self):
         """Generates the path from the resource name after object creation."""
-        self.path = _create_relative_resource_data_path(self.name)
+        if _is_resource_name_correct(self.name):
+            self.path = _create_relative_resource_data_path(self.name)
 
 
 @dataclass

--- a/src/seedcase_sprout/sprout_checks/get_sprout_resource_errors.py
+++ b/src/seedcase_sprout/sprout_checks/get_sprout_resource_errors.py
@@ -1,6 +1,6 @@
 import seedcase_sprout.check_datapackage as cdp
 from seedcase_sprout.internals import (
-    _create_relative_resource_data_path,
+    _create_resource_data_path,
 )
 from seedcase_sprout.sprout_checks.check_fields_not_blank import (
     check_fields_not_blank,
@@ -61,7 +61,6 @@ def _check_resource_path_format(
     """
     name = properties.get("name")
     path = properties.get("path")
-    expected_path = _create_relative_resource_data_path(name)
 
     if (
         # Do not check path if name is incorrect
@@ -70,8 +69,11 @@ def _check_resource_path_format(
         or not isinstance(path, str)
         # Do not flag blank errors twice
         or path == ""
-        or path == expected_path
     ):
+        return []
+
+    expected_path = _create_resource_data_path(name)
+    if path == expected_path:
         return []
 
     return [

--- a/src/seedcase_sprout/sprout_checks/get_sprout_resource_errors.py
+++ b/src/seedcase_sprout/sprout_checks/get_sprout_resource_errors.py
@@ -1,5 +1,5 @@
 import seedcase_sprout.check_datapackage as cdp
-from seedcase_sprout.internals._create_relative_resource_data_path import (
+from seedcase_sprout.internals import (
     _create_relative_resource_data_path,
 )
 from seedcase_sprout.sprout_checks.check_fields_not_blank import (


### PR DESCRIPTION
# Description

Moved the internal resource data path creator function into internals and split out the check functionality. Since it's use often co-incides with checking (like in `get_sprout_resource_errors.py`) and since it's cleaner if not too many distinct actions (creating but also checking) happen within an internal function, I moved that bit out. Also simplifies the return type.

This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
