### PR TITLE
build: :heavy_plus_sign: add jinja2 dependency explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires-python = ">=3.12"
 dependencies = [
     "dacite>=1.9.2",
     "deepmerge>=2.0",
+    "jinja2>=3.1.6",
     "jsonschema>=4.23.0",
     "polars>=1.26.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1823,6 +1823,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dacite" },
     { name = "deepmerge" },
+    { name = "jinja2" },
     { name = "jsonschema" },
     { name = "polars" },
 ]
@@ -1849,6 +1850,7 @@ dev = [
 requires-dist = [
     { name = "dacite", specifier = ">=1.9.2" },
     { name = "deepmerge", specifier = ">=2.0" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "polars", specifier = ">=1.26.0" },
 ]


### PR DESCRIPTION
# Description

This PR adds jinja2 as a dependency.
When installing `example-seed-beetle` in non-dev-mode, I saw that jinja2 wasn't being installed because it is not declared as a dependency in Sprout.

Maybe we haven't seen this before because jinja2 is a dependency of many dev-only dependencies in Sprout and of commitizen in `example-seed-beetle`. And `uv sync` installs dev dependencies.

Let me know if I'm wrong, but this is my understanding :sweat_smile: 


This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
