### PR TITLE
refactor: :recycle: rename to properties_script

### DIFF
--- a/src/seedcase_sprout/__init__.py
+++ b/src/seedcase_sprout/__init__.py
@@ -16,7 +16,7 @@ from .check_properties import (
     check_properties,
     check_resource_properties,
 )
-from .create_properties_template import create_properties_template
+from .create_properties_script import create_properties_script
 from .examples import (
     ExamplePackage,
     example_data,
@@ -64,7 +64,7 @@ __all__ = [
     "TableSchemaForeignKeyProperties",
     "TableSchemaProperties",
     "read_properties",
-    "create_properties_template",
+    "create_properties_script",
     # Example properties -----
     "example_package_properties",
     "example_resource_properties",

--- a/src/seedcase_sprout/create_properties_script.py
+++ b/src/seedcase_sprout/create_properties_script.py
@@ -8,20 +8,20 @@ from seedcase_sprout.properties import PackageProperties
 from seedcase_sprout.write_file import write_file
 
 
-def create_properties_template(path: Path | None = None) -> Path:
-    """Creates the properties template with default values.
+def create_properties_script(path: Path | None = None) -> Path:
+    """Creates the properties script with default values.
 
     Args:
         path: The path to the package folder. Defaults to the current working directory.
 
     Returns:
-        The path to the template file.
+        The path to the newly created properties script.
 
     Examples:
         ```{python}
         import seedcase_sprout as sp
 
-        sp.create_properties_template()
+        sp.create_properties_script()
         ```
     """
     package_path = PackagePath(path)
@@ -32,6 +32,6 @@ def create_properties_template(path: Path | None = None) -> Path:
         properties=PackageProperties.from_default(name=package_path.root().name)
     )
 
-    template_path = package_path.properties_template()
-    template_path.parent.mkdir(exist_ok=True)
-    return write_file(text, template_path)
+    script_path = package_path.properties_script()
+    script_path.parent.mkdir(exist_ok=True)
+    return write_file(text, script_path)

--- a/src/seedcase_sprout/paths.py
+++ b/src/seedcase_sprout/paths.py
@@ -102,6 +102,6 @@ class PackagePath:
         """
         return list(self.resource_batch(resource_name).glob("*.parquet"))
 
-    def properties_template(self) -> Path:
-        """Path to the properties template."""
+    def properties_script(self) -> Path:
+        """Path to the properties script."""
         return self.root() / "scripts" / "properties.py"

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -13,7 +13,7 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
     a new file will be created.
 
     Args:
-        properties: The properties to write. Use `create_properties_template()` to
+        properties: The properties to write. Use `create_properties_script()` to
         create a file with your properties object.
         path: A `Path` to the `datapackage.json` file.
 

--- a/tests/test_create_properties_script.py
+++ b/tests/test_create_properties_script.py
@@ -7,19 +7,19 @@ from zoneinfo import ZoneInfo
 
 import time_machine
 
-from seedcase_sprout.create_properties_template import create_properties_template
+from seedcase_sprout.create_properties_script import create_properties_script
 from seedcase_sprout.paths import PackagePath
 from seedcase_sprout.properties import LicenseProperties, PackageProperties
 
 
 @patch("seedcase_sprout.properties.uuid4", return_value=UUID(int=1))
 @time_machine.travel(datetime(2024, 5, 14, 5, 0, 1, tzinfo=ZoneInfo("UTC")), tick=False)
-def test_creates_template_with_default_values(mock_uuid, tmp_cwd):
-    """Should create a template with default values."""
-    template_path = create_properties_template()
+def test_creates_script_with_default_values(mock_uuid, tmp_cwd):
+    """Should create a script with default values."""
+    script_path = create_properties_script()
 
-    assert template_path == PackagePath().properties_template()
-    properties = load_properties(template_path)
+    assert script_path == PackagePath().properties_script()
+    properties = load_properties(script_path)
     assert properties == PackageProperties(
         name=tmp_cwd.name,
         title="",
@@ -33,10 +33,10 @@ def test_creates_template_with_default_values(mock_uuid, tmp_cwd):
 
 def test_works_with_custom_path(tmp_path):
     """Should work with a custom path."""
-    template_path = create_properties_template(tmp_path)
+    script_path = create_properties_script(tmp_path)
 
-    assert template_path == PackagePath(tmp_path).properties_template()
-    assert load_properties(template_path).name == tmp_path.name
+    assert script_path == PackagePath(tmp_path).properties_script()
+    assert load_properties(script_path).name == tmp_path.name
 
 
 def load_properties(path: Path) -> PackageProperties:


### PR DESCRIPTION
# Description

This PR renames `properties_template` to `properties_script`.


This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
