### PR TITLE
build: :pencil2: fix name to `create_properties_script` in `_quarto.yml`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -114,7 +114,7 @@ quartodoc:
     - title: "Property functions"
       desc: "Functions used to work with properties."
       contents:
-        - create_properties_template
+        - create_properties_script
         - read_properties
 
     - title: "Path functions"


### PR DESCRIPTION
# Description

Forgot to rename this in the `_quarto.yml` file.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
