### PR TITLE
fix: :bug: change `fields_match` to be an array in `extract_resource_properties()`

### DIFF
--- a/src/seedcase_sprout/extract_resource_properties.py
+++ b/src/seedcase_sprout/extract_resource_properties.py
@@ -45,7 +45,9 @@ def extract_resource_properties(data: pl.DataFrame) -> ResourceProperties:
 
     resource_properties = ResourceProperties()
     resource_properties.type = "table"
-    resource_properties.schema = TableSchemaProperties(fields_match="equal")
+    # The fields_match property is supposed to be a string, but there's an error in the
+    # JSON schema. This should be fixed in datapackage V2.1.
+    resource_properties.schema = TableSchemaProperties(fields_match=["equal"])
     resource_properties.schema.fields = _extract_field_properties(data)
 
     return resource_properties

--- a/tests/test_extract_resource_properties.py
+++ b/tests/test_extract_resource_properties.py
@@ -28,7 +28,7 @@ def _keep_extractable_properties(
     )
 
     return ResourceProperties(
-        schema=TableSchemaProperties(fields=fields, fields_match="equal"),
+        schema=TableSchemaProperties(fields=fields, fields_match=["equal"]),
         type="table",
     )
 


### PR DESCRIPTION
# Description

It's supposed to be a string, but there's an error in the JSON schema. According to a PR in the [data package repo](https://github.com/frictionlessdata/datapackage/pull/1051), this should be fixed in datapackage V2.1 🤞 

I encountered this issue bc the website build fails bc there was an error in `resources.qmd` when writing the properties.

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
