### PR TITLE
docs: :memo: link to raw sprout logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align=center>
     <a href="https://sprout.seedcase-project.org/">
-        <img src="_extensions/seedcase-project/seedcase-theme/logos/navbar-logo-seedcase-sprout.svg" height="150" alt="Sprout website"/>
+        <img src="https://raw.githubusercontent.com/seedcase-project/seedcase-sprout/main/_extensions/seedcase-project/seedcase-theme/logos/navbar-logo-seedcase-sprout.svg" height="150" alt="Link to Sprout website"/>
     </a>
 </p>
 


### PR DESCRIPTION
# Description

Instead of using a relative path. This should work when we publish to PyPI (relative path doesn't).

This PR needs a quick review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
