### PR TITLE
refactor: :recycle: change `fields_match` type to list

### DIFF
--- a/src/seedcase_sprout/properties.py
+++ b/src/seedcase_sprout/properties.py
@@ -302,7 +302,7 @@ class TableSchemaProperties(Properties):
     Attributes:
         fields (list[FieldProperties] | None): Specifies the fields in this table
             schema.
-        fields_match (FieldsMatchType | None): Specifies how fields in the table
+        fields_match (list[FieldsMatchType] | None): Specifies how fields in the table
             schema match the fields in the data source.
         primary_key (list[str] | str | None): A primary key is a field name or an array
             of field names, whose values must uniquely identify each row in the table.
@@ -321,7 +321,7 @@ class TableSchemaProperties(Properties):
     """
 
     fields: list[FieldProperties] | None = None
-    fields_match: FieldsMatchType | None = None
+    fields_match: list[FieldsMatchType] | None = None
     primary_key: list[str] | str | None = None
     unique_keys: list[list[str]] | None = None
     foreign_keys: list[TableSchemaForeignKeyProperties] | None = None

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -120,7 +120,7 @@ def test_allows_overriding_defaults():
         ({"fields": ["a field"]}, TableSchemaForeignKeyProperties(fields=["a field"])),
         ({"required": False}, ConstraintsProperties(required=False)),
         ({"name": "a field name"}, FieldProperties(name="a field name")),
-        ({"fieldsMatch": "exact"}, TableSchemaProperties(fields_match="exact")),
+        ({"fieldsMatch": ["exact"]}, TableSchemaProperties(fields_match=["exact"])),
         (
             {
                 "name": "resource-name",


### PR DESCRIPTION
# Description

This PR changes the type of `fields_match` to list after https://github.com/seedcase-project/seedcase-sprout/pull/1392.

Closes #1408 

This PR needs a quick review.

## Checklist

- [x] Added or updated tests
- [x] Updated documentation
- [x] Ran `just run-all`
