### PR TITLE
docs: :bug: glossary wasn't rendering so used Polars instead

### DIFF
--- a/_extensions/seedcase-project/seedcase-theme/glossary.json
+++ b/_extensions/seedcase-project/seedcase-theme/glossary.json
@@ -1,7 +1,7 @@
 [
   {
     "item": "data",
-    "description": "Data can mean any piece of information that someone would like to use to answer questions. What is considered data (and metadata) is highly dependent on people and what they intend to do with information that is collected. In the context of Seedcase Sprout, data is any information collected for the purposes of doing analyses on them to answer questions. An example might be data collected from people participating in a study on health and disease. "
+    "description": "Data can mean any piece of information that someone would like to use to answer questions. What is considered data (and metadata) is highly dependent on people and what they intend to do with information that is collected. In the context of Seedcase Sprout, data is any information collected for the purposes of doing analyses on them to answer questions. An example might be data collected from people participating in a study on health and disease."
   },
   {
     "item": "data package",

--- a/_extensions/seedcase-project/seedcase-theme/glossary.json
+++ b/_extensions/seedcase-project/seedcase-theme/glossary.json
@@ -1,0 +1,18 @@
+[
+  {
+    "item": "data",
+    "description": "Data can mean any piece of information that someone would like to use to answer questions. What is considered data (and metadata) is highly dependent on people and what they intend to do with information that is collected. In the context of Seedcase Sprout, data is any information collected for the purposes of doing analyses on them to answer questions. An example might be data collected from people participating in a study on health and disease. "
+  },
+  {
+    "item": "data package",
+    "description": "A \"container\" for data that describes a coherent collection of data. It consists of two parts: data resources and properties. "
+  },
+  {
+    "item": "data resource",
+    "description": "A single piece of data, such as a table or data file, and its properties, included in a data package. It contains the actual data, documented following the Data Package standard. "
+  },
+  {
+    "item": "properties",
+    "description": "Metadata that describes the entire data package and each of the data resources within it. At the package level, the properties include the package name and description, contributors, licenses, and more. At the resource level, they describe attributes such as the resource name, description, schema, and data fields. All properties are stored in `datapackage.json` in the root directory of the package. "
+  }
+]

--- a/_extensions/seedcase-project/seedcase-theme/glossary.json
+++ b/_extensions/seedcase-project/seedcase-theme/glossary.json
@@ -5,14 +5,14 @@
   },
   {
     "item": "data package",
-    "description": "A \"container\" for data that describes a coherent collection of data. It consists of two parts: data resources and properties. "
+    "description": "A \"container\" for data that describes a coherent collection of data. It consists of two parts: data resources and properties."
   },
   {
     "item": "data resource",
-    "description": "A single piece of data, such as a table or data file, and its properties, included in a data package. It contains the actual data, documented following the Data Package standard. "
+    "description": "A single piece of data, such as a table or data file, and its properties, included in a data package. It contains the actual data, documented following the Data Package standard."
   },
   {
     "item": "properties",
-    "description": "Metadata that describes the entire data package and each of the data resources within it. At the package level, the properties include the package name and description, contributors, licenses, and more. At the resource level, they describe attributes such as the resource name, description, schema, and data fields. All properties are stored in `datapackage.json` in the root directory of the package. "
+    "description": "Metadata that describes the entire data package and each of the data resources within it. At the package level, the properties include the package name and description, contributors, licenses, and more. At the resource level, they describe attributes such as the resource name, description, schema, and data fields. All properties are stored in `datapackage.json` in the root directory of the package."
   }
 ]

--- a/docs/glossary.qmd
+++ b/docs/glossary.qmd
@@ -2,10 +2,29 @@
 title: "Glossary"
 ---
 
-::: hidden
-{{< glossary "data package" >}}
-{{< glossary "data resource" >}}
-{{< glossary properties >}}
-:::
+```{python}
+#| echo: false
+#| output: asis
+# Create the glossary table
+import polars as pl
 
-{{< glossary table=true >}}
+keep_items = ["data package", "data resource", "properties"]
+glossary = (
+    # This only works when building the website. Append `../`
+    # to the path when running the code in the Quarto Notebook.
+    pl.read_json('_extensions/seedcase-project/seedcase-theme/glossary.json')
+        .filter(pl.col("item").is_in(keep_items))
+        .rename(str.capitalize)
+)
+
+@pl.Config(
+    tbl_formatting = "ASCII_MARKDOWN",
+    tbl_hide_column_data_types = True,
+    tbl_hide_dataframe_shape = True,
+    tbl_width_chars=500,
+    fmt_str_lengths=500
+)
+def as_md_table(data: pl.DataFrame) -> str:
+    return str(data)
+print(as_md_table(glossary))
+```

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -5,7 +5,7 @@ jupyter: python3
 ---
 
 At the core of Sprout is the
-[{{< glossary "data package">}}](../glossary.qmd), which is a
+["data package"](/docs/glossary.qmd), which is a
 standardized way of structuring and documenting data. This guide will
 show you how to create and manage data packages using Sprout.
 
@@ -26,7 +26,7 @@ root folder of the data package.
 With that in mind, let's make a data package! A data package always
 needs a `datapackage.json` file. This file will be located at the root
 of your data package and contains a set of
-[{{< glossary "properties">}}](../glossary.qmd), or metadata about the
+[properties](/docs/glossary.qmd), or metadata about the
 data package and the data resources within it. To set up this
 `datapackage.json` file, you first need a set of properties you want to
 add to the data package. Then, you can use the

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -4,8 +4,8 @@ order: 2
 jupyter: python3
 ---
 
-In each [data package](/docs/design/interface/outputs.qmd#outputs) are
-[data resources](/docs/design/interface/outputs.qmd#outputs), which
+In each [data package](/docs/glossary.qmd) are
+[data resources](/docs/glossary.qmd), which
 contain conceptually standalone sets of data. This page shows you how to
 create and manage data resources inside a data package using Sprout. You
 will need to have already [created a data


### PR DESCRIPTION
# Description

The glossary table wasn't rendering properly and I couldn't figure out why.

So instead, I converted the glossary into a JSON and used Polars to make a table.

Thoughts on this approach?

Closes #1415

This PR needs an in-depth review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
