### PR TITLE
docs: :memo: refine the purpose and description in landing page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -41,7 +41,7 @@ div.quarto-about-jolla {
 ::::: hero-banner
 :::: landing-page-block
 ::: hero-text
-## Standardise your data and simplify managing it
+## Standardise your data and streamline its management
 
 Sprout is a **Python package**, and the backbone of the [**Seedcase
 Project**](https://seedcase-project.org), with a flexible interface

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: Grow structured, organized, and *usable* data
+title: Grow structured, organised, and *usable* data
 format:
   seedcase-theme-html:
     toc: false
@@ -15,6 +15,8 @@ about:
   image-shape: rectangle
   image-width: 25em
   links:
+    - text: "Learn more"
+      href: "https://sprout.seedcase-project.org/docs/"
     - text: "Install Sprout"
       href: "https://sprout.seedcase-project.org/docs/guide/installation"
     - text: "Explore guide"
@@ -39,21 +41,19 @@ div.quarto-about-jolla {
 ::::: hero-banner
 :::: landing-page-block
 ::: hero-text
-## Streamlined data management for every workflow
+## Standardise your data and simplify managing it
 
-**Sprout** is at the backbone of the [**Seedcase
-Project**](https://seedcase-project.org), offering a flexible solution
-to structure and manage your data.
+Sprout is a **Python package**, and the backbone of the [**Seedcase
+Project**](https://seedcase-project.org), with a flexible interface
+designed and built for people whose task is to build up, structure,
+describe, and organise data for research projects. It is made to offer
+flexibility and control over the individual steps in a data processing
+and management workflow.
 
-Sprout is a **Python package** with a flexible interface directed at
-those whose task is to build up and organise data for a project or
-research study, as well as those who want more control over
-individual steps in the data processing and management workflow.
-
-We designed this package mainly for computationally technical personnel,
-such as data engineers or software developers. It's designed to be
-easily extended and customized to fit your needs, within a framework
-that ensures your data is structured, organized, and usable.
+We built this package mainly for digitally-technical personnel, such as
+data engineers or software developers. It's designed to be easily
+extended and customized to fit your needs, within a framework that
+ensures your data is structured, organised, and usable.
 :::
 ::::
 :::::
@@ -64,8 +64,6 @@ that ensures your data is structured, organized, and usable.
 We would love your feedback or contributions! Head over to our [GitHub
 repository](https://github.com/seedcase-project/seedcase-sprout) to
 share your ideas or contribute code. Your input makes us better!
-
-<!-- TODO: Add link to a guide on how to contribute in more detail -->
 :::
 
 :::: {.content-hidden when-format="pdf"}


### PR DESCRIPTION
# Description

I matched the title with the other descriptions of Sprout used throughout the repo.

I added a link to "learn more" in the overview.

And I simplified/refined the purpose and explanation text.

Closes #893

This PR needs a quick review.
