### PR TITLE
docs: :memo: list contributors in overview page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,7 @@
 project:
   type: seedcase-theme
+  pre-render:
+    - sh ./tools/get-contributors.sh
   render:
     - "docs/*"
     - "index.qmd"

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+jupyter: python3
 ---
 
 ## What is Sprout?
@@ -63,3 +64,14 @@ and details about the interface.
 -   [Design](/docs/design/index.qmd): The design section describes the
     architecture and interface of Sprout, the requirements, use-cases,
     user personas, and the [C4 model](https://c4model.com/).
+
+## Contributors
+
+These are the people who have contributed to Sprout by submitting
+changes through pull requests :tada:
+
+```{python}
+#| echo: false
+#| output: asis
+!cat contributors.txt.tmp
+```

--- a/tools/get-contributors.sh
+++ b/tools/get-contributors.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Get a list of contributors to the Seedcase Sprout repository
+# and save it to contributors.txt.tmp file. It also:
+#
+# - Formats users into Markdown links to their GitHub profiles.
+# - Removes any usernames with the word "bot" in them.
+# - Removes the trailing comma from the list.
+gh api \
+  /repos/seedcase-project/seedcase-sprout/contributors \
+  --template '{{range .}} [\@{{.login}}]({{.html_url}}){{"\n"}}{{end}}' | \
+  grep -v "\[bot\]" | \
+  tr '\n' ', ' | \
+  sed -e 's/,$//' > contributors.txt.tmp


### PR DESCRIPTION
# Description

Puts a list of contributors, along with links to the GitHub, in the Overview page.

Closes #1363

This PR needs a quick review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
