### PR TITLE
docs: :memo: move contributing text into own file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To install Sprout to contribute, you first need to install
 [uv](https://docs.astral.sh/uv/) and
 [justfile](https://just.systems/man/en/packages.html). We use uv and
 justfile to manage our project, such as to install development
-dependencies. Both uv and justfile website have a more detailed guide on
+dependencies. Both the uv and justfile websites have a more detailed guide on
 using uv, but below are some simple instructions to get you started.
 
 To install uv, run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+## Issues and bugs :bug:
+
+The easiest way to contribute is to report issues or bugs that you might
+find while using Sprout. You can do this by creating a
+[new](https://github.com/seedcase-project/seedcase-sprout/issues/new/choose)
+issue on our GitHub repository.
+
+## Adding or modifying content :pencil2:
+
+If you would like to contribute content, please check out our
+[guidebook](https://guidebook.seedcase-project.org/) for more specific
+details on how we work and develop. It is a regularly evolving document,
+so is at various states of completion.
+
+To install Sprout to contribute, you first need to install
+[uv](https://docs.astral.sh/uv/) and
+[justfile](https://just.systems/man/en/packages.html). We use uv and
+justfile to manage our project, such as to install development
+dependencies. Both uv and justfile website have a more detailed guide on
+using uv, but below are some simple instructions to get you started.
+
+To install uv, run:
+
+``` bash
+pipx install uv
+```
+
+Then, open a terminal so that the working directory is the root of this
+project (`seedcase-sprout/`) and run:
+
+``` bash
+just install-deps
+```
+
+We keep all our development workflows in the `justfile`, so you can
+explore it to see what commands are available. To see a list of commands
+available, run:
+
+``` bash
+just
+```

--- a/README.md
+++ b/README.md
@@ -58,30 +58,10 @@ Guide](https://sprout.seedcase-project.org/docs/guide/installation).
 
 ## Contributing
 
-If you would like to contribute, please check out our
-[guidebook](https://guidebook.seedcase-project.org/) for more specific
-details on how we work and develop. It is a regularly evolving document,
-so is at various states of completion.
-
-To install Sprout to contribute, you first need to install
-[uv](https://docs.astral.sh/uv/) and
-[justfile](https://just.systems/man/en/packages.html). We use uv and
-justfile to manage our project, such as to install development
-dependencies. Both uv and justfile website have a more detailed guide on
-using uv, but below are some simple instructions to get you started.
-
-To install uv, run:
-
-``` bash
-pipx install uv
-```
-
-Then, open a terminal so that the working directory is the root of this
-project (`seedcase-sprout/`) and run:
-
-``` bash
-just install-deps
-```
+Check out our [contributing
+page](https://sprout.seedcase-project.org/CONTRIBUTING/) for information
+on how to contribute to the project, including how to set up your
+development environment.
 
 ## Licensing
 

--- a/README.qmd
+++ b/README.qmd
@@ -43,30 +43,9 @@ Guide](https://sprout.seedcase-project.org/docs/guide/installation).
 
 ## Contributing
 
-If you would like to contribute, please check out our
-[guidebook](https://guidebook.seedcase-project.org/) for more specific
-details on how we work and develop. It is a regularly evolving document,
-so is at various states of completion.
-
-To install Sprout to contribute, you first need to install
-[uv](https://docs.astral.sh/uv/) and
-[justfile](https://just.systems/man/en/packages.html). We use uv and
-justfile to manage our project, such as to install development
-dependencies. Both uv and justfile website have a more detailed guide on
-using uv, but below are some simple instructions to get you started.
-
-To install uv, run:
-
-``` bash
-pipx install uv
-```
-
-Then, open a terminal so that the working directory is the root of this
-project (`seedcase-sprout/`) and run:
-
-``` bash
-just install-deps
-```
+Check out our [contributing page](https://sprout.seedcase-project.org/CONTRIBUTING/)
+for information on how to contribute to the project, including how to
+set up your development environment.
 
 ## Licensing
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,7 @@ project:
   render:
     - "docs/*"
     - "index.qmd"
+    - "CONTRIBUTING.md"
   post-render:
     - find resources/patient-data/batch/ -iname "*.parquet" -delete
 
@@ -48,7 +49,9 @@ website:
       pinned: true
       style: "floating"
       contents:
+        - docs/index.qmd
         - docs/releases.qmd
+        - CONTRIBUTING.md
     - id: design
       contents:
         - text: "Design"


### PR DESCRIPTION
# Description

Both PyOpenSci and the OSSF badge best practices suggest a dedicated `CONTRIBUTING.md` file. We have one in the `.github` repo, but it is too generic.

This PR needs a quick review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
