### PR TITLE
docs: :pencil2: rename leftovers and move `field_properties` into `ResourceProperties`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,7 +8,7 @@ project:
     - "index.qmd"
     - "CONTRIBUTING.md"
   post-render:
-    - find resources/patient-data/batch/ -iname "*.parquet" -delete
+    - find resources/patient/batch/ -iname "*.parquet" -delete
 
 website:
   title: "Seedcase Sprout"

--- a/docs/design/interface/flows.qmd
+++ b/docs/design/interface/flows.qmd
@@ -62,10 +62,10 @@ flowchart
 The flow for extracting resource properties from data. This is useful
 when the data is in a format that contains metadata about the data, such
 as a CSV file with a header row that contains the column names. The
-`extract_resource_properties()` function cannot extract all required
+`extract_field_properties()` function cannot extract all required
 properties from the data, so both `TableSchemaProperties` and
 `ResourceProperties` will need many of their fields filled in after
-extraction. The output of the `extract_resource_properties()` function
+extraction. The output of the `extract_field_properties()` function
 can be used to generate a Python script to give you a starting point for
 writing the resource properties. Afterwards, if you want to update the
 resource properties, you'll edit this Python script and then re-run your
@@ -79,11 +79,11 @@ properties.
 flowchart
     data[("DataFrame<br>(Tidy)")]
     properties_extracted[("ResourceProperties<br>(extracted)")]
-    extract_resource_properties("extract_resource_properties()")
+    extract_field_properties("extract_field_properties()")
     python_script("Python script<br>(generated with<br>extracted properties)")
 
-    data --> extract_resource_properties
-    extract_resource_properties --> properties_extracted
+    data --> extract_field_properties
+    extract_field_properties --> properties_extracted
     properties_extracted --> python_script
 ```
 

--- a/docs/design/interface/functions.qmd
+++ b/docs/design/interface/functions.qmd
@@ -168,16 +168,16 @@ flowchart
     function --> out
 ```
 
-### {{< var done >}} `extract_resource_properties(data)`
+### {{< var done >}} `extract_field_properties(data)`
 
-See the help documentation with `help(extract_resource_properties)` for
+See the help documentation with `help(extract_field_properties)` for
 more details.
 
 ```{mermaid}
 flowchart
     in_data_path[/data/]
-    function("extract_resource_properties()")
-    out[("ResourceProperties")]
+    function("extract_field_properties()")
+    out[("list[FieldProperties]")]
     in_data_path --> function
     function --> out
 ```

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -118,12 +118,12 @@ correct, as all data in the resource must match the properties. While
 you can create a resource properties object manually using
 `ResourceProperties`, it can be quite intensive and time-consuming if
 you, for example, have many columns in your data. To make this process
-easier, `extract_resource_properties()` allows you to create an initial
+easier, `extract_field_properties()` allows you to create an initial
 resource properties object by extracting as much information as possible
 from the Polars DataFrame with your data. Afterwards, you can edit these
 properties as needed.
 
-Now you are ready to use `extract_resource_properties()` to extract the
+Now you are ready to use `extract_field_properties()` to extract the
 resource properties from the data. This function tries to infer the data
 types from the data, but it might not get it right, so make sure to
 double check the output. It is not possible to infer information that is
@@ -131,8 +131,17 @@ not included in the data, like a description of what the data contains
 or the unit of the data.
 
 ```{python}
-resource_properties = sp.extract_resource_properties(
+field_properties = sp.extract_field_properties(
     data=data
+)
+resource_properties = sp.ResourceProperties(
+    name = "patients",
+    path = "resources/patients/data.parquet",
+    title = "Patients Data",
+    description = "This data resource contains data about patients in a diabetes study.",
+    schema=sp.TableSchemaProperties(
+        fields=field_properties
+    )
 )
 print(resource_properties)
 ```
@@ -140,6 +149,7 @@ print(resource_properties)
 <!-- TODO: pprint doesn't work well with nested objects like resource_properties above.
 So, for now, we'll use print here. but, we should find an alternative.
  -->
+<!-- TODO: The last required field `Path` is still missing at this point -->
 
 You may be able to see that some things are missing, for instance, the
 individual columns (called `fields`) don't have any descriptions. You
@@ -150,19 +160,6 @@ properties to confirm what is missing:
 #| error: true
 print(sp.check_resource_properties(resource_properties))
 ```
-
-Time to fill in the missing fields of the resource properties:
-
-```{python}
-# TODO: Need to consider/design how editing can be done in an easier, user-friendly way.
-# TODO: Add more detail when we know what can and can't be extracted.
-resource_properties.name = "patient-data"
-resource_properties.path = "resources/patient-data/data.parquet"
-resource_properties.title = "Patient Data"
-resource_properties.description = "This data resource contains data about..."
-```
-
-<!-- TODO: The last required field `Path` is still missing at this point -->
 
 ## Creating a data resource
 


### PR DESCRIPTION
# Description

Fixing the website build after the change to `extract_field_properties` from `extract_resource_properties`.

Doesn't need a review.

## Checklist

- [x] Updated documentation
- [x] Ran `just run-all`
