### PR TITLE
docs: :memo: update resource guide

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,8 +7,6 @@ project:
     - "docs/*"
     - "index.qmd"
     - "CONTRIBUTING.md"
-  post-render:
-    - find resources/patients/batch/ -iname "*.parquet" -delete
 
 website:
   title: "Seedcase Sprout"

--- a/docs/guide/_python-minimal-package-setup.qmd
+++ b/docs/guide/_python-minimal-package-setup.qmd
@@ -8,8 +8,8 @@ from tempfile import TemporaryDirectory
 
 temp_path = TemporaryDirectory()
 package_path = Path(temp_path.name) / "diabetes-study"
-
 subprocess.run(["uv", "init", str(package_path)])
+package_path = sp.PackagePath(package_path)
 
 def file_tree(package_path: Path) -> list[Path]:
     """Show the file tree for the data package, excluding `.git` files.

--- a/docs/guide/_python-minimal-package-setup.qmd
+++ b/docs/guide/_python-minimal-package-setup.qmd
@@ -1,0 +1,34 @@
+```{python setup}
+#| include: false
+import seedcase_sprout as sp
+import subprocess
+import seedir as sd
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+temp_path = TemporaryDirectory()
+package_path = Path(temp_path.name) / "diabetes-study"
+
+subprocess.run(["uv", "init", str(package_path)])
+
+def file_tree(package_path: Path) -> list[Path]:
+    """Show the file tree for the data package, excluding `.git` files.
+
+    Args:
+        package_path: The path to the package directory.
+
+    Returns:
+        A string representation of the file tree.
+    """
+    # Check if the path is a directory and exists
+    if not package_path.is_dir():
+        raise ValueError(f"{package_path} is not a directory.")
+
+    return sd.seedir(
+        package_path,
+        style="emoji",
+        exclude_folders=[".git"],
+        first="folders",
+        printout=False
+    )
+```

--- a/docs/guide/_python-package-properties.qmd
+++ b/docs/guide/_python-package-properties.qmd
@@ -1,0 +1,36 @@
+```{python}
+#| include: false
+# This is only to check that it runs.
+properties = sp.PackageProperties.from_default(
+    name="diabetes-study",
+    title="A Study on Diabetes",
+    # You can write Markdown below, with the helper `sp.dedent()`.
+    description=sp.dedent("""
+        # Data from a 2021 study on diabetes prevalence
+
+        This data package contains data from a study conducted in 2021 on the
+        *prevalence* of diabetes in various populations. The data includes:
+
+        - demographic information
+        - health metrics
+        - survey responses about lifestyle
+        """),
+    contributors=[
+        sp.ContributorProperties(
+            title="Jamie Jones",
+            email="jamie_jones@example.com",
+            path="example.com/jamie_jones",
+            roles=["creator"],
+        )
+    ],
+    licenses=[
+        sp.LicenseProperties(
+            name="ODC-BY-1.0",
+            path="https://opendatacommons.org/licenses/by",
+            title="Open Data Commons Attribution License 1.0",
+        )
+    ],
+    # We don't include the rest in this guide, the above is only to
+    # show what it might look like writing properties.
+)
+```

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -158,42 +158,7 @@ properties = sp.PackageProperties(
 )
 ```
 
-```{python}
-#| include: false
-# This is only to check that it runs.
-properties = sp.PackageProperties.from_default(
-    name="diabetes-study",
-    title="A Study on Diabetes",
-    # You can write Markdown below, with the helper `sp.dedent()`.
-    description=sp.dedent("""
-        # Data from a 2021 study on diabetes prevalence
-
-        This data package contains data from a study conducted in 2021 on the
-        *prevalence* of diabetes in various populations. The data includes:
-
-        - demographic information
-        - health metrics
-        - survey responses about lifestyle
-        """),
-    contributors=[
-        sp.ContributorProperties(
-            title="Jamie Jones",
-            email="jamie_jones@example.com",
-            path="example.com/jamie_jones",
-            roles=["creator"],
-        )
-    ],
-    licenses=[
-        sp.LicenseProperties(
-            name="ODC-BY-1.0",
-            path="https://opendatacommons.org/licenses/by",
-            title="Open Data Commons Attribution License 1.0",
-        )
-    ],
-    # We don't include the rest in this guide, the above is only to
-    # show what it might look like writing properties.
-)
-```
+{{< include _python-package-properties.qmd >}}
 
 Now that you've filled in some of the package properties, it's time to
 create your `datapackage.json` file with these properties. You can use

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -22,7 +22,7 @@ Right now, your file structure should look a bit like:
 
 ```{python}
 #| echo: false
-print(file_tree(package_path))
+print(file_tree(package_path.root()))
 ```
 
 Now, time to make a data package! A data package always needs a
@@ -66,7 +66,7 @@ uv run main.py
 
 ```{python}
 #| include: false
-sp.create_properties_script(package_path)
+sp.create_properties_script(package_path.root())
 ```
 
 This will create a `properties.py` file in the newly created `scripts/`
@@ -85,7 +85,7 @@ touch scripts/__init__.py
 #| include: false
 import subprocess
 # Touch file in scripts/ folder in the package_path
-subprocess.run(["touch", str(package_path / "scripts/__init__.py")])
+subprocess.run(["touch", str(package_path.root() / "scripts/__init__.py")])
 ```
 :::
 
@@ -94,7 +94,7 @@ The file structure should now look like:
 ```{python}
 #| echo: false
 # List all files in directory
-print(file_tree(package_path))
+print(file_tree(package_path.root()))
 ```
 
 Inside the `scripts/properties.py` file, you will find a template for
@@ -102,7 +102,7 @@ creating the properties of your data package. It looks like:
 
 ```{python}
 #| echo: false
-print((sp.PackagePath(package_path).properties_script()).read_text())
+print(package_path.properties_script().read_text())
 ```
 
 You can now start filling in that script by using the comments included,
@@ -192,7 +192,7 @@ if __name__ == "__main__":
 # Only to check that it runs.
 sp.write_properties(
     properties=properties,
-    path=sp.PackagePath(package_path).properties()
+    path=package_path.properties()
 )
 ```
 
@@ -217,7 +217,7 @@ properties you added to it. Now, you will see the added
 
 ```{python}
 #| echo: false
-print(file_tree(package_path))
+print(file_tree(package_path.root()))
 ```
 
 ## Creating a README of the properties
@@ -269,7 +269,7 @@ uv run main.py
 readme_text = sp.as_readme_text(properties)
 sp.write_file(
     string=readme_text,
-    path=sp.PackagePath(package_path).readme()
+    path=package_path.readme()
 )
 ```
 
@@ -278,7 +278,7 @@ package:
 
 ```{python}
 #| echo: false
-print(file_tree(package_path))
+print(file_tree(package_path.root()))
 ```
 
 ## Editing package properties

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -45,7 +45,9 @@ beginning to end of creating your data package. Open the `main.py` file
 in your Python project, delete everything in it and copy and paste the
 below code into it.
 
-``` python
+```{python}
+#| eval: false
+#| filename: "main.py"
 import seedcase_sprout as sp
 
 def main():
@@ -169,7 +171,9 @@ So in your `main.py`, include this code:
 
 <!-- TODO: How to auto-run the code below? -->
 
-``` python
+```{python}
+#| eval: false
+#| filename: "main.py"
 import seedcase_sprout as sp
 from scripts.properties import properties
 
@@ -225,7 +229,9 @@ wanting to learn more about your data package. You can use
 to a README file. Let's create a README file with the properties of the
 data package you just created by writing it in the `main.py` file.
 
-``` python
+```{python}
+#| eval: false
+#| filename: "main.py"
 import seedcase_sprout as sp
 from scripts.properties import properties
 

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -8,41 +8,9 @@ At the core of Sprout is the ["data package"](/docs/glossary.qmd), which
 is a standardized way of structuring and documenting data. This guide
 will show you how to create and manage data packages using Sprout.
 
-```{python setup}
-#| include: false
-import seedcase_sprout as sp
-import subprocess
-import seedir as sd
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
-temp_path = TemporaryDirectory()
-package_path = Path(temp_path.name) / "diabetes-study"
-subprocess.run(["uv", "init", str(package_path)])
-
-def file_tree(package_path: Path) -> list[Path]:
-    """Show the file tree for the data package, excluding `.git` files.
-
-    Args:
-        package_path: The path to the package directory.
-
-    Returns:
-        A string representation of the file tree.
-    """
-    # Check if the path is a directory and exists
-    if not package_path.is_dir():
-        raise ValueError(f"{package_path} is not a directory.")
-
-    return sd.seedir(
-        package_path,
-        style="emoji",
-        exclude_folders=[".git"],
-        first="folders",
-        printout=False
-    )
-```
-
 {{< include _preamble.qmd >}}
+
+{{< include _python-minimal-package-setup.qmd >}}
 
 ## Creating a data package
 

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -40,8 +40,8 @@ are:
 7.  Re-build the data package's `README.md` file from the updated
     `datapackage.json` file.
 8.  If you need to update the properties at a later point, you would
-    edit the resource properties script, run the `main.py` file to
-    re-create the properties, and then write the properties to the
+    edit the resource properties script and run the `main.py` file to
+    re-create the properties and write them to the
     `datapackage.json` file.
 
 Many of these steps are taken care of by functions in Sprout, but some

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -39,8 +39,9 @@ are:
 6.  Merge the data batches into a new resource data file.
 7.  Re-build the data package's `README.md` file from the updated
     `datapackage.json` file.
-8.  If you need to update the properties at a later point, you can use
-    `update_resource_properties()` and then write the result to the
+8.  If you need to update the properties at a later point, you would
+    edit the resource properties script, run the `main.py` file to
+    re-create the properties, and then write the properties to the
     `datapackage.json` file.
 
 Many of these steps are taken care of by functions in Sprout, but some
@@ -231,124 +232,6 @@ below.
 ```{python}
 #| echo: false
 print(package_path.resource_properties_script("patients").read_text())
-```
-
-```{python}
-#| filename: "scripts/resource_properties_patients.py"
-import seedcase_sprout as sp
-
-resource_properties_patients = sp.ResourceProperties(
-    ## Required:
-    name="patients",
-    title="",
-    description="",
-    ## Optional:
-    type="table",
-    format="parquet",
-    mediatype="application/parquet",
-    schema=sp.TableSchemaProperties(
-        ## Required
-        fields=[
-            sp.FieldProperties(
-                ## Required
-                name="id",
-                type="integer",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="age",
-                type="integer",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="sex",
-                type="string",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="height",
-                type="number",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="weight",
-                type="number",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="diabetes_type",
-                type="string",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-        ],
-        ## Optional
-        # fields_match=["equal"],
-        # primary_key=[""],
-        # unique_keys=[[""]],
-        # foreign_keys=[
-        #     sp.TableSchemaForeignKeyProperties(
-        #         ## Required
-        #         fields=[""],
-        #         reference=sp.ReferenceProperties(
-        #             ## Required
-        #             resource="",
-        #             fields=[""],
-        #         ),
-        #     ),
-        # ],
-    ),
-    # sources=[
-    #     sp.SourceProperties(
-    #         ## Required:
-    #         title="",
-    #         ## Optional:
-    #         path="",
-    #         email="",
-    #         version="",
-    #     ),
-    # ],
-)
 ```
 :::
 

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -32,9 +32,9 @@ are:
 2.  Create the folders for the new resource within the package and save
     the resource properties in the `datapackage.json` file.
 3.  Optionally store the raw data in a `raw/` folder in the package, so
-    that you can keep the original data separate from the tided data.
-4.  Tidy the data as needed and converting into a Polars DataFrame (if
-    it isn't already) before adding it to the resource.
+    that you can keep the original data separate from the tidied data.
+4.  Tidy the data as needed and convert it into a Polars DataFrame (if
+    you haven't already) before adding it to the resource.
 5.  Add your tidy data as a batch of data to the resource.
 6.  Merge the data batches into a new resource data file.
 7.  Re-build the data package's `README.md` file from the updated
@@ -101,7 +101,7 @@ structure:
 print(file_tree(package_path.root()))
 ```
 
-And the `raw/patients.csv` includes data about patients with diabetes,
+And the `raw/patients.csv` file includes data about patients with diabetes,
 and it looks like this:
 
 ```{python}
@@ -136,9 +136,9 @@ properties script. Since a data package can contain multiple resources,
 the resource's `name` must also be unique.
 
 To ease the process of adding `fields` to your resource properties,
-Sprout provides a function called `extract_field_properties()` which
+Sprout provides a function called `extract_field_properties()`, which
 allows you to extract information from the Polars DataFrame with your
-data to have some initial properties. Use these extracted properties as
+data. Use these extracted properties as
 a starting point and edit as needed.
 
 ::: callout-warning
@@ -371,8 +371,8 @@ resource_properties_patients = sp.ResourceProperties(
 
 ::: callout-warning
 If the `title` and `description` properties are not filled in, you'll
-get a `CheckError` when you try to use `write_properties()` so that the
-resource's properties get included into the `datapackage.json` file.
+get a `CheckError` when you try to use `write_properties()` to save
+the resource's properties to the `datapackage.json` file.
 
 Below you can see how `CheckErrors` look like when you try to check the
 resource properties without filling in the required fields. When you use
@@ -385,7 +385,7 @@ the properties are always correct before writing them to the
 ```{python}
 #| error: true
 #| eval: false
-print(sp.check_resource_properties(resource_properties_patients))
+sp.check_resource_properties(resource_properties_patients)
 ```
 
 ```
@@ -437,8 +437,7 @@ properties = sp.PackageProperties(
 )
 ```
 
-Now that you have the properties for the resource, you can add it to
-your existing data package. A data package can contain multiple
+A data package can contain multiple
 resources, so their `name` property must be unique. This `name` property
 is what will be used later to create the folder structure for that
 resource.
@@ -505,8 +504,8 @@ simplified flow of steps involved in adding batch files. Also see the
 these batch files in the resource's folder.
 :::
 
-Batch files are used to store data in a data package each time you add
-new or modified data to a resource. These batch files will be used to
+Each time you add new or modified data to a resource, this data is
+stored in a batch file. These batch files will be used to
 create the final data file that is actually used as the resource at the
 path `resource/<name>/data.parquet`. The first time a batch file is
 saved, it will create the folders necessary for the resource.
@@ -525,7 +524,7 @@ from scripts.resource_properties_patients import resource_properties_patients
 
 def main():
     # Previous code is excluded to keep it short.
-    # New code inserted to the bottom -----
+    # New code inserted at the bottom -----
     # Save the batch data.
     sp.write_resource_batch(
         data=raw_data_patients,
@@ -559,10 +558,10 @@ Now that you've stored the data as a batch file, you can build the
 resource. This Parquet file is built from all the data in the `batch/`
 folder. Since there is only one batch data file stored in the resource's
 folder, only this one will be used to build the data resource's Parquet
-file. Before you can create this main Parquet file, you need to read in
+file. To create this main Parquet file, you need to read in
 all the batch files, join them together, and, optionally, do any
 additional processing on the data before writing it to the file. The
-functions are `read_resource_batches()`, `join_resource_batches()`, and
+functions to use are `read_resource_batches()`, `join_resource_batches()`, and
 `write_resource_data()`. Several of these functions will internally run
 checks via `check_data()`.
 
@@ -575,7 +574,7 @@ Let's add these functions to the `main.py` file to make the
 # This code is shortened to only show what was changed.
 def main():
     # Previous code is excluded to keep it short.
-    # New code inserted to the bottom -----
+    # New code inserted at the bottom -----
     # Read in all the batch data files for the resource as a list.
     batch_data = sp.read_resource_batches(
         resource_properties=resource_properties_patients

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -4,29 +4,29 @@ order: 2
 jupyter: python3
 ---
 
-In each [data package](/docs/glossary.qmd) are
-[data resources](/docs/glossary.qmd), which
-contain conceptually standalone sets of data. This page shows you how to
-create and manage data resources inside a data package using Sprout. You
-will need to have already [created a data
-package](packages.qmd#creating-a-data-package).
+In each [data package](/docs/glossary.qmd) are [data
+resources](/docs/glossary.qmd), which contain conceptually standalone
+sets of data. This page shows you how to create and manage data
+resources inside a data package using Sprout. You will need to have
+already [created a data package](packages.qmd#creating-a-data-package).
 
 {{< include _preamble.qmd >}}
 
 ::: callout-important
 Data resources can only be created from [tidy
-data](https://design.seedcase-project.org/data/). Before you can store
-it, you need to process it into a tidy format, ideally using Python so
-that you have a record of the steps taken to clean and transform the
-data.
+data](https://design.seedcase-project.org/data/) in [Polars
+DataFrames]((https://pola.rs/)). Before you can store it, you need to
+process it into a tidy format, ideally using Python so that you have a
+record of the steps taken to clean and transform the data.
 :::
 
-Putting your data into a data package makes it easier for yourself and
-others to use later on. The steps you'll take to get your data into the
-structure used by Sprout are:
+The steps you'll take to get your data into the structure used by Sprout
+are:
+
+<!-- TODO: update when finished with updating the rest of the guide -->
 
 1.  Create the properties for the resource, using the original data as a
-    starting point, and edit as needed.
+    starting point, and edit the resource properties script as needed.
 2.  Create the folders for the new resource within the package and save
     the resource properties in the `datapackage.json` file.
 3.  Add your data to the batches of data for the resource.
@@ -41,18 +41,16 @@ structure used by Sprout are:
 
 ```{python setup}
 #| include: false
-# This `setup` code chunk creates a package and downloads some data.
+# This `setup` code chunk sets up the package from the packages guide and downloads some data.
 import polars as pl
-import seedcase_sprout as sp
-from tempfile import mkdtemp
-from pathlib import Path
+from tempfile import TemporaryDirectory, mkdtemp
 from urllib.request import urlretrieve
 
-temp_path = Path(mkdtemp())
-package_path = sp.PackagePath(temp_path / "diabetes-study")
-package_path.root().mkdir()
+package_path = sp.PackagePath(package_path)
 
 package_properties = sp.example_package_properties()
+sp.create_properties_script(package_path.root())
+
 sp.write_properties(
     properties=package_properties,
     path=package_path.properties(),
@@ -63,104 +61,452 @@ sp.write_file(readme, package_path.readme())
 # TODO: Maybe eventually move this over into Sprout as an example dataset, rather than via a URL.
 # Download the example data to a temporary location.
 url = "https://raw.githubusercontent.com/seedcase-project/data/refs/heads/main/patients/patients.csv"
-raw_data_path = temp_path / "patients.csv"
+raw_data_path = package_path.root() / "rawdata" / "patients.csv"
+raw_data_path.parent.mkdir(exist_ok=True)
 urlretrieve(
     url,
     raw_data_path
 )
 
-data = pl.read_csv(raw_data_path)
+raw_data_patients = pl.read_csv(raw_data_path)
 ```
 
 Making a data resource requires that you have data that can be made into
 a resource in the first place. Usually, generated or collected data
 starts out in a bit of a "raw" shape that needs some working. This work
-needs to be done before adding the data as a data package, since Sprout
+needs to be done before adding the data to a data package, since Sprout
 assumes that the data is already
-[tidy](https://design.seedcase-project.org/data/). For this guide, we
-use (fake) data that is already tidy and loaded into a Polars DataFrame:
+[tidy](https://design.seedcase-project.org/data/).
 
-```{python}
-data.head(5)
-```
-
-If you want to follow this guide with the same data, you can find it
+For this guide, you will use (fake) data that is already tidy. You can
+find the data
 [here](https://raw.githubusercontent.com/seedcase-project/data/refs/heads/main/patients/patients.csv).
+We've placed this data in a `rawdata/` folder in the data package and
+called it `patients.csv`, so that we can keep the original data separate
+from the processed data.
 
-Before we start, you need to import Sprout as well as other helper
-packages:
-
-```{python}
-import seedcase_sprout as sp
-
-# For pretty printing of output
-from pprint import pprint
-```
-
-Since Sprout only works with [Polars DataFrames](https://pola.rs/), we
-will need to load in the data using Polars:
+`patients.csv` includes data about patients with diabetes, and it looks
+like this:
 
 ```{python}
-import polars as pl
-
-original_data = pl.read_csv(raw_data_path)
-print(original_data)
+#| echo: false
+raw_data_patients.head(5)
 ```
 
-Then we can continue with the next steps.
+At this point, your data package `diabetes-study` has the following
+structure:
+
+```{python}
+#| echo: false
+print(file_tree(package_path.root()))
+```
 
 ## Extracting resource properties from the data
 
-You'll start by creating the resource's properties. Before you can store
-data in your data package, you need to describe it using properties
-(i.e., metadata). The resource's properties are what allow other people
-to understand what your data is about and to use it more easily. These
-properties also define what it means for data in the resource to be
-correct, as all data in the resource must match the properties. While
-you can create a resource properties object manually using
-`ResourceProperties`, it can be quite intensive and time-consuming if
-you, for example, have many columns in your data. To make this process
-easier, `extract_field_properties()` allows you to create an initial
-resource properties object by extracting as much information as possible
-from the Polars DataFrame with your data. Afterwards, you can edit these
-properties as needed.
+Before you can store resource data in your data package, you need to
+describe its [properties](/docs/glossary.qmd). The resource's properties
+are what allow other people to understand what your data is about and to
+use it more easily.
 
-Now you are ready to use `extract_field_properties()` to extract the
-resource properties from the data. This function tries to infer the data
-types from the data, but it might not get it right, so make sure to
-double check the output. It is not possible to infer information that is
-not included in the data, like a description of what the data contains
-or the unit of the data.
+The resource's properties also define what it means for data in the
+resource to be correct, as all data in the resource must match the
+properties. Sprout checks that the properties are correctly filled in
+and that no required properties fields are missing. It also checks that
+the data matches the properties, so that you can be sure that data
+actually contains what you expect it to contain.
 
-```{python}
-field_properties = sp.extract_field_properties(
-    data=data
-)
-resource_properties = sp.ResourceProperties(
-    name = "patients",
-    path = "resources/patients/data.parquet",
-    title = "Patients Data",
-    description = "This data resource contains data about patients in a diabetes study.",
-    schema=sp.TableSchemaProperties(
-        fields=field_properties
+Like with the package properties, you will create a properties script
+for the resource that allows you to easily edit the properties later on.
+You can do this by using the `create_properties_script()` function. This
+function needs the `resource_name` and optionally the `fields` (i.e.,
+columns or variables) that you want to include in the resource.
+
+The `resource_name` is the name of the resource, which is used to
+identify the resource in the data package. It is required and *should
+not* be changed, since it's used in the file name of the resource
+properties script. Since a data package can contain multiple resources,
+the resource `name` must also be unique.
+
+To ease the process of adding `fields` to your resource properties,
+Sprout provides a function called `extract_field_properties()` which
+allows you to extract information from the Polars DataFrame with your
+data to have some initial properties. Use these extracted properties as
+a starting point and edit as needed.
+
+::: callout-warning
+`extract_field_properties()` extracts the field properties from the
+Polars DataFrame's \[schema\] and maps the Polars data type to a [Data
+Package field
+type](https://datapackage.org/standard/table-schema/#field-types).
+
+The mapping is not perfect, so you may need to edit the extracted
+properties to ensure that they are as you want them to be.
+:::
+
+Let's add these steps to our `main.py` file: First, we need to load the
+original data from the `rawdata/` folder into a Polars DataFrame, then
+we can extract the field properties from it, and use these properties in
+the creation of our resource properties script:
+
+```python
+import polars as pl
+
+def main():
+    # Your existing code here...
+
+    # Load the "patients" raw data from the CSV file.
+    raw_data_patients = pl.read_csv(package_path.root() / "rawdata" / "patients.csv")
+    # Extract field properties.
+    field_properties = sp.extract_field_properties(
+        data=raw_data_patients,
     )
-)
-print(resource_properties)
+    # Create the resource properties script.
+    sp.create_resource_properties_script(
+        resource_name="patients",
+        fields=field_properties,
+    )
+
+if __name__ == "__main__":
+    main()
 ```
 
-<!-- TODO: pprint doesn't work well with nested objects like resource_properties above.
-So, for now, we'll use print here. but, we should find an alternative.
- -->
-<!-- TODO: The last required field `Path` is still missing at this point -->
+Then run the `main.py` file in your Terminal to create the resource
+properties script:
 
-You may be able to see that some things are missing, for instance, the
-individual columns (called `fields`) don't have any descriptions. You
-will have to manually add this yourself. You can run a check on the
-properties to confirm what is missing:
+``` {.bash filename="Terminal"}
+uv run main.py
+```
+
+```{python}
+#| include: false
+raw_data_patients = pl.read_csv(package_path.root() / "rawdata" / "patients.csv")
+field_properties = sp.extract_field_properties(data=raw_data_patients)
+sp.create_resource_properties_script(
+        resource_name="patients",
+        fields=field_properties,
+        path=package_path.root()
+    )
+```
+
+
+To see the contents of the newly created resource properties script,
+open the `scripts/resource_properties_patients.py` file on your
+computer. It should look like this:
+
+::: {.callout collapse="true"}
+## Full content of the `resource_properties_patients.py` file
+
+```{python}
+
+import seedcase_sprout as sp
+
+resource_properties_patients = sp.ResourceProperties(
+    ## Required:
+    name="patients",
+    title="",
+    description="",
+    ## Optional:
+    type="table",
+    format="parquet",
+    mediatype="application/parquet",
+    schema=sp.TableSchemaProperties(
+        ## Required
+        fields=[
+            sp.FieldProperties(
+                ## Required
+                name="id",
+                type="integer",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="age",
+                type="integer",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="sex",
+                type="string",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="height",
+                type="number",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="weight",
+                type="number",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="diabetes_type",
+                type="string",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+        ],
+        ## Optional
+        # fields_match=["equal"],
+        # primary_key=[""],
+        # unique_keys=[[""]],
+        # foreign_keys=[
+        #     sp.TableSchemaForeignKeyProperties(
+        #         ## Required
+        #         fields=[""],
+        #         reference=sp.ReferenceProperties(
+        #             ## Required
+        #             resource="",
+        #             fields=[""],
+        #         ),
+        #     ),
+        # ],
+    ),
+    # sources=[
+    #     sp.SourceProperties(
+    #         ## Required:
+    #         title="",
+    #         ## Optional:
+    #         path="",
+    #         email="",
+    #         version="",
+    #     ),
+    # ],
+)
+```
+:::
+
+In the resource properties script, the `name` property is set to
+`patients`. However, the two other required properties, `title` and
+`description`, are empty. You will need to fill these in yourself in the
+script, like so:
+
+```{python}
+#| eval: false
+resource_properties_patients = sp.ResourceProperties(
+    ## Required:
+    name="patients",
+    title="Patients Data",
+    description="This data resource contains data about patients in a diabetes study.",
+    ## Optional:
+    # Rest of the properties...
+)
+```
+
+::: callout-warning
+## `CheckError` when properties are not filled in
+
+If the `title` and `description` properties are not filled in, Sprout
+will raise a `CheckError` when try to include the resource's properties
+in the `datapackage.json` file.
+
+Below you can see how `CheckErrors` look like when you try to check the
+resource properties without filling in the required fields.
+
+The used function `check_resource_properties()` checks that the
+properties are correctly filled in and that no required fields are
+missing. It's used internally in Sprout to ensure that the properties
+are correct before writing them to the `datapackage.json` file.
 
 ```{python}
 #| error: true
-print(sp.check_resource_properties(resource_properties))
+#| eval: false
+print(sp.check_resource_properties(resource_properties_patients))
+```
+
+```
+  +-+---------------- 1 ----------------
+    | seedcase_sprout.check_datapackage.check_error.CheckError: Error at `$.description` caused by `blank`: The 'description' field is blank, please fill it in.
+    +---------------- 2 ----------------
+    | seedcase_sprout.check_datapackage.check_error.CheckError: Error at `$.title` caused by `blank`: The 'title' field is blank, please fill it in.
+    +------------------------------------
+```
+:::
+
+Now, the resource properties for patients include the following
+information (printed as a dictionary representation that omits empty
+fields):
+
+```{python}
+#| echo: false
+resource_properties_patients = sp.ResourceProperties(
+    ## Required:
+    name="patients",
+    title="Patients Data",
+    description="This data resource contains data about the patients included in the diabetes study.",
+    ## Optional:
+    type="table",
+    format="parquet",
+    mediatype="application/parquet",
+    schema=sp.TableSchemaProperties(
+        ## Required
+        fields=[
+            sp.FieldProperties(
+                ## Required
+                name="id",
+                type="integer",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="age",
+                type="integer",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="sex",
+                type="string",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="height",
+                type="number",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="weight",
+                type="number",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+            sp.FieldProperties(
+                ## Required
+                name="diabetes_type",
+                type="string",
+                ## Optional
+                # title="",
+                # format="",
+                # description="",
+                # example="",
+                # categories=[],
+                # categories_ordered=False,
+            ),
+        ],
+        ## Optional
+        # fields_match=["equal"],
+        # primary_key=[""],
+        # unique_keys=[[""]],
+        # foreign_keys=[
+        #     sp.TableSchemaForeignKeyProperties(
+        #         ## Required
+        #         fields=[""],
+        #         reference=sp.ReferenceProperties(
+        #             ## Required
+        #             resource="",
+        #             fields=[""],
+        #         ),
+        #     ),
+        # ],
+    ),
+    # sources=[
+    #     sp.SourceProperties(
+    #         ## Required:
+    #         title="",
+    #         ## Optional:
+    #         path="",
+    #         email="",
+    #         version="",
+    #     ),
+    # ],
+)
+```
+
+```{python}
+sp.pprint(resource_properties_patients.compact_dict)
+```
+
+<!-- TODO: pprint doesn't work well with nested objects like resource_properties above.
+So, for now, we'll use a compact dict representation  here. but, we should find an alternative.
+ -->
+
+To include these properties in your data package, you need to include
+the resource properties in the `properties.py` file of your data
+package. You can do this by adding the following lines to the
+`properties.py` file:
+
+```{python}
+#| eval: false
+# Below the existing imports, add:
+from .resource_properties_patients import resource_properties_patients
+
+properties = sp.PackageProperties(
+    # Your existing properties here...
+    # Uncomment the resource properties line below and add `resource_properties_patients`:
+    resources=[
+        resource_properties_patients,
+    ],
+)
 ```
 
 ## Creating a data resource
@@ -185,7 +531,7 @@ Let's take a look at the current files and folders in the data package:
 
 ```{python}
 #| echo: false
-print(list(package_path.root().glob("**/*")))
+print(file_tree(package_path.root()))
 ```
 
 This shows that the data package already includes a `datapackage.json`
@@ -227,8 +573,9 @@ simplified flow of steps involved in adding batch files.
 
 Batch files are used to store data in a data package each time you add
 data to a resource. These batch files will be used to create the data
-file that is actually used as the resource at the path `resource/<name>/data.parquet`.
-The first time a batch file is saved, it will create the folders necessary for the resource.
+file that is actually used as the resource at the path
+`resource/<name>/data.parquet`. The first time a batch file is saved, it
+will create the folders necessary for the resource.
 
 As shown above, the data is currently stored loaded as a Polars
 DataFrame called `data`. Now, it's time to store this data in the
@@ -238,8 +585,8 @@ resource's folder by using:
 
 ```{python}
 sp.write_resource_batch(
-    data=original_data,
-    resource_properties=resource_properties
+    data=raw_data_patients,
+    resource_properties=resource_properties_patients,
 )
 ```
 
@@ -344,6 +691,6 @@ sp.write_properties(
 #| include: false
 import shutil
 
-if temp_path.exists():
-    shutil.rmtree(temp_path)
+if Path(temp_path.name).exists():
+    shutil.rmtree(Path(temp_path.name))
 ```

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -1,23 +1,25 @@
 ---
-title: "Creating and managing data resources"
+title: "Creating and managing the properties and data for data resources"
 order: 2
 jupyter: python3
 ---
 
 In each [data package](/docs/glossary.qmd) are [data
-resources](/docs/glossary.qmd), which contain conceptually standalone
-sets of data. This page shows you how to create and manage data
-resources inside a data package using Sprout. You will need to have
-already [created a data package](packages.qmd#creating-a-data-package).
+resources](/docs/glossary.qmd), which contain conceptually distinct sets
+of data. This page shows you how to use Sprout to create and manage data
+resources inside a data package. You will need to have [created a data
+package](packages.qmd#creating-a-data-package) already.
 
 {{< include _preamble.qmd >}}
 
 ::: callout-important
 Data resources can only be created from [tidy
 data](https://design.seedcase-project.org/data/) in [Polars
-DataFrames]((https://pola.rs/)). Before you can store it, you need to
-process it into a tidy format, ideally using Python so that you have a
-record of the steps taken to clean and transform the data.
+DataFrames](https://decisions.seedcase-project.org/why-polars-for-data-cleaning/).
+Before you can store it, you need to process it into a tidy format,
+ideally using Python so that you have a record of the steps taken to
+clean and transform the data. Either way, the tidy data needs to be read
+into a Polars DataFrame before you can use it in Sprout.
 :::
 
 The steps you'll take to get your data into the structure used by Sprout
@@ -26,29 +28,35 @@ are:
 <!-- TODO: update when finished with updating the rest of the guide -->
 
 1.  Create the properties for the resource, using the original data as a
-    starting point, and edit the resource properties script as needed.
+    starting point, and then edit the resource properties as needed.
 2.  Create the folders for the new resource within the package and save
     the resource properties in the `datapackage.json` file.
-3.  Add your data to the batches of data for the resource.
-4.  Merge the data batches into a new resource data file.
-5.  Re-build the data package's `README.md` file from the updated
+3.  Optionally store the raw data in a `raw/` folder in the package, so
+    that you can keep the original data separate from the tided data.
+4.  Tidy the data as needed and converting into a Polars DataFrame (if
+    it isn't already) before adding it to the resource.
+5.  Add your tidy data as a batch of data to the resource.
+6.  Merge the data batches into a new resource data file.
+7.  Re-build the data package's `README.md` file from the updated
     `datapackage.json` file.
-6.  If you need to update the properties at a later point, you can use
+8.  If you need to update the properties at a later point, you can use
     `update_resource_properties()` and then write the result to the
     `datapackage.json` file.
 
+Many of these steps are taken care of by functions in Sprout, but some
+require writing your own code.
+
 {{< include _python-minimal-package-setup.qmd >}}
 
-```{python setup}
+```{python setup-data-package}
 #| include: false
-# This `setup` code chunk sets up the package from the packages guide and downloads some data.
+# This `setup-data-package` code chunk sets up the package from the packages guide and downloads some data.
 import polars as pl
-from tempfile import TemporaryDirectory, mkdtemp
+from tempfile import mkdtemp
 from urllib.request import urlretrieve
 
-package_path = sp.PackagePath(package_path)
-
 package_properties = sp.example_package_properties()
+# Original `package_path` is from the include chunk above.
 sp.create_properties_script(package_path.root())
 
 sp.write_properties(
@@ -61,7 +69,7 @@ sp.write_file(readme, package_path.readme())
 # TODO: Maybe eventually move this over into Sprout as an example dataset, rather than via a URL.
 # Download the example data to a temporary location.
 url = "https://raw.githubusercontent.com/seedcase-project/data/refs/heads/main/patients/patients.csv"
-raw_data_path = package_path.root() / "rawdata" / "patients.csv"
+raw_data_path = package_path.root() / "raw" / "patients.csv"
 raw_data_path.parent.mkdir(exist_ok=True)
 urlretrieve(
     url,
@@ -81,17 +89,9 @@ assumes that the data is already
 For this guide, you will use (fake) data that is already tidy. You can
 find the data
 [here](https://raw.githubusercontent.com/seedcase-project/data/refs/heads/main/patients/patients.csv).
-We've placed this data in a `rawdata/` folder in the data package and
-called it `patients.csv`, so that we can keep the original data separate
-from the processed data.
-
-`patients.csv` includes data about patients with diabetes, and it looks
-like this:
-
-```{python}
-#| echo: false
-raw_data_patients.head(5)
-```
+We've placed this data in a `raw/` folder in the data package and called
+it `patients.csv`, so that we can keep the original data separate from
+the processed data.
 
 At this point, your data package `diabetes-study` has the following
 structure:
@@ -101,7 +101,15 @@ structure:
 print(file_tree(package_path.root()))
 ```
 
-## Extracting resource properties from the data
+And the `raw/patients.csv` includes data about patients with diabetes,
+and it looks like this:
+
+```{python}
+#| echo: false
+raw_data_patients.head(5)
+```
+
+## Extracting properties from the data
 
 Before you can store resource data in your data package, you need to
 describe its [properties](/docs/glossary.qmd). The resource's properties
@@ -125,7 +133,7 @@ The `resource_name` is the name of the resource, which is used to
 identify the resource in the data package. It is required and *should
 not* be changed, since it's used in the file name of the resource
 properties script. Since a data package can contain multiple resources,
-the resource `name` must also be unique.
+the resource's `name` must also be unique.
 
 To ease the process of adding `fields` to your resource properties,
 Sprout provides a function called `extract_field_properties()` which
@@ -135,8 +143,8 @@ a starting point and edit as needed.
 
 ::: callout-warning
 `extract_field_properties()` extracts the field properties from the
-Polars DataFrame's \[schema\] and maps the Polars data type to a [Data
-Package field
+Polars DataFrame's schema and maps the Polars data type to a Data
+Package [field
 type](https://datapackage.org/standard/table-schema/#field-types).
 
 The mapping is not perfect, so you may need to edit the extracted
@@ -144,34 +152,49 @@ properties to ensure that they are as you want them to be.
 :::
 
 Let's add these steps to our `main.py` file: First, we need to load the
-original data from the `rawdata/` folder into a Polars DataFrame, then
-we can extract the field properties from it, and use these properties in
+original data from the `raw/` folder into a Polars DataFrame, then we
+can extract the field properties from it, and use these properties in
 the creation of our resource properties script:
 
-```python
+```{python}
+#| filename: "main.py"
+#| eval: false
+import seedcase_sprout as sp
+from scripts.properties import properties
 import polars as pl
 
 def main():
-    # Your existing code here...
+    # Create the properties script in default location.
+    sp.create_properties_script()
 
-    # Load the "patients" raw data from the CSV file.
-    raw_data_patients = pl.read_csv(package_path.root() / "rawdata" / "patients.csv")
-    # Extract field properties.
+    # New code here -----
+    # Load the "patients" raw, but tidy, data from the CSV file.
+    raw_data_patients = pl.read_csv(package_path.root() / "raw" / "patients.csv")
+    # Extract field properties from the raw, but tidy, data.
     field_properties = sp.extract_field_properties(
         data=raw_data_patients,
     )
-    # Create the resource properties script.
+    # Create the resource properties script. This is only created once, it will
+    # not be overwritten if it already exists.
     sp.create_resource_properties_script(
         resource_name="patients",
         fields=field_properties,
     )
+    # New code ends here -----
+
+    # Save the properties to `datapackage.json`.
+    sp.write_properties(properties=properties)
+    # Create text for a README of the data package.
+    readme_text = sp.as_readme_text(properties)
+    # Write the README text to a `README.md` file.
+    sp.write_file(readme_text, sp.PackagePath().readme())
 
 if __name__ == "__main__":
     main()
 ```
 
-Then run the `main.py` file in your Terminal to create the resource
-properties script:
+Then run the `main.py` file in your Terminal, which will create the
+resource properties script:
 
 ``` {.bash filename="Terminal"}
 uv run main.py
@@ -179,7 +202,8 @@ uv run main.py
 
 ```{python}
 #| include: false
-raw_data_patients = pl.read_csv(package_path.root() / "rawdata" / "patients.csv")
+# Run to confirm the code works.
+raw_data_patients = pl.read_csv(package_path.root() / "raw" / "patients.csv")
 field_properties = sp.extract_field_properties(data=raw_data_patients)
 sp.create_resource_properties_script(
         resource_name="patients",
@@ -188,16 +212,29 @@ sp.create_resource_properties_script(
     )
 ```
 
-
-To see the contents of the newly created resource properties script,
-open the `scripts/resource_properties_patients.py` file on your
-computer. It should look like this:
-
-::: {.callout collapse="true"}
-## Full content of the `resource_properties_patients.py` file
+Your folders and files should now look like:
 
 ```{python}
+#| echo: false
+print(file_tree(package_path.root()))
+```
 
+## Writing the resource properties
+
+Open the newly created `scripts/resource_properties_patients.py` file in
+order to make edits to it. See the full contents in the callout block
+below.
+
+::: {.callout-note collapse="true"}
+## `scripts/resource_properties_patients.py` content
+
+```{python}
+#| echo: false
+print(package_path.resource_properties_script("patients").read_text())
+```
+
+```{python}
+#| filename: "scripts/resource_properties_patients.py"
 import seedcase_sprout as sp
 
 resource_properties_patients = sp.ResourceProperties(
@@ -328,24 +365,22 @@ resource_properties_patients = sp.ResourceProperties(
     title="Patients Data",
     description="This data resource contains data about patients in a diabetes study.",
     ## Optional:
-    # Rest of the properties...
+    # Rest of the properties that we don't show here, but that is above ...
 )
 ```
 
 ::: callout-warning
-## `CheckError` when properties are not filled in
-
-If the `title` and `description` properties are not filled in, Sprout
-will raise a `CheckError` when try to include the resource's properties
-in the `datapackage.json` file.
+If the `title` and `description` properties are not filled in, you'll
+get a `CheckError` when you try to use `write_properties()` so that the
+resource's properties get included into the `datapackage.json` file.
 
 Below you can see how `CheckErrors` look like when you try to check the
-resource properties without filling in the required fields.
-
-The used function `check_resource_properties()` checks that the
-properties are correctly filled in and that no required fields are
-missing. It's used internally in Sprout to ensure that the properties
-are correct before writing them to the `datapackage.json` file.
+resource properties without filling in the required fields. When you use
+`check_resource_properties()` on the `ResourceProperties` object, it
+checks if everything is correctly filled in and that no required fields
+are missing. It's used internally in `write_properties()` to ensure that
+the properties are always correct before writing them to the
+`datapackage.json` file.
 
 ```{python}
 #| error: true
@@ -368,127 +403,20 @@ fields):
 
 ```{python}
 #| echo: false
-resource_properties_patients = sp.ResourceProperties(
-    ## Required:
-    name="patients",
-    title="Patients Data",
-    description="This data resource contains data about the patients included in the diabetes study.",
-    ## Optional:
-    type="table",
-    format="parquet",
-    mediatype="application/parquet",
-    schema=sp.TableSchemaProperties(
-        ## Required
-        fields=[
-            sp.FieldProperties(
-                ## Required
-                name="id",
-                type="integer",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="age",
-                type="integer",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="sex",
-                type="string",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="height",
-                type="number",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="weight",
-                type="number",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-            sp.FieldProperties(
-                ## Required
-                name="diabetes_type",
-                type="string",
-                ## Optional
-                # title="",
-                # format="",
-                # description="",
-                # example="",
-                # categories=[],
-                # categories_ordered=False,
-            ),
-        ],
-        ## Optional
-        # fields_match=["equal"],
-        # primary_key=[""],
-        # unique_keys=[[""]],
-        # foreign_keys=[
-        #     sp.TableSchemaForeignKeyProperties(
-        #         ## Required
-        #         fields=[""],
-        #         reference=sp.ReferenceProperties(
-        #             ## Required
-        #             resource="",
-        #             fields=[""],
-        #         ),
-        #     ),
-        # ],
-    ),
-    # sources=[
-    #     sp.SourceProperties(
-    #         ## Required:
-    #         title="",
-    #         ## Optional:
-    #         path="",
-    #         email="",
-    #         version="",
-    #     ),
-    # ],
-)
+resource_properties_patients.title = "Patients Data"
+resource_properties_patients.description = "This data resource contains data about the patients included in the diabetes study."
 ```
 
 ```{python}
 sp.pprint(resource_properties_patients.compact_dict)
 ```
 
-<!-- TODO: pprint doesn't work well with nested objects like resource_properties above.
+```{=html}
+<!--
+TODO: pprint doesn't work well with nested objects like resource_properties above.
 So, for now, we'll use a compact dict representation  here. but, we should find an alternative.
- -->
+-->
+```
 
 To include these properties in your data package, you need to include
 the resource properties in the `properties.py` file of your data
@@ -497,59 +425,51 @@ package. You can do this by adding the following lines to the
 
 ```{python}
 #| eval: false
-# Below the existing imports, add:
+#| filename: "properties.py"
+# Import the resource properties object.
 from .resource_properties_patients import resource_properties_patients
 
 properties = sp.PackageProperties(
     # Your existing properties here...
-    # Uncomment the resource properties line below and add `resource_properties_patients`:
     resources=[
         resource_properties_patients,
     ],
 )
 ```
 
-## Creating a data resource
-
-Now that you have the properties for the resource, you can create the
-properties for the resource within your existing data package. A data
-package can contain multiple resources, so their `name` property
-must be unique. This `name` property is what will be used later
-to create the folder structure for that resource.
-
-We assume that you've already created a data package (for example, by
-following the [package guide](packages.qmd#creating-a-data-package)) and
-stored the path to it as a `PackagePath` object in the `package_path`
-variable. In this guide, the root folder of the package is in a
-temporary folder:
-
-```{python}
-print(package_path.root())
-```
-
-Let's take a look at the current files and folders in the data package:
-
-```{python}
-#| echo: false
-print(file_tree(package_path.root()))
-```
-
-This shows that the data package already includes a `datapackage.json`
-file and a `README.md` file.
+Now that you have the properties for the resource, you can add it to
+your existing data package. A data package can contain multiple
+resources, so their `name` property must be unique. This `name` property
+is what will be used later to create the folder structure for that
+resource.
 
 The next step is to write the resource properties to the
-`datapackage.json` file. Before they are added, they will be checked to
-confirm that they are correctly filled in and that no required fields
-are missing. You can use the `PackagePath().properties()` helper
-function to give you the location of the `datapackage.json` file based
-on the path to your package.
+`datapackage.json` file. Since we included the `resource_properties`
+object directly into the `scripts/properties.py` file, and since the
+`scripts/properties.py` file is imported already in `main.py`, we can
+simply re-run the `main.py` file and it will update both the
+`datapackage.json` file and the `README.md` file.
+
+``` {.bash filename="Terminal"}
+uv run main.py
+```
+
+{{< include _python-package-properties.qmd >}}
 
 ```{python}
-#| eval: false
-# TODO: Update to use template when it has been implemented
+#| include: false
+# Only to check that it runs.
+properties.resources = [
+    resource_properties_patients,
+]
 sp.write_properties(
     properties=properties,
     path=package_path.properties(),
+)
+readme_text = sp.as_readme_text(properties)
+sp.write_file(
+    string=readme_text,
+    path=package_path.readme()
 )
 ```
 
@@ -560,137 +480,149 @@ resource properties have been added:
 print(sp.read_properties(package_path.properties()))
 ```
 
-<!-- TODO: pprint doesn't work well with nested objects like resource_properties above.
+```{=html}
+<!--
+TODO: pprint doesn't work well with nested objects like resource_properties above.
 So, for now, we'll use print here. but, we should find an alternative.
- -->
+-->
+```
+
+::: callout-note
+If you need to update the resource properties later on, you can simply
+edit the `scripts/resource_properties_patients.py` file and then re-run
+the `main.py` file to update the `datapackage.json` file and the
+`README.md` file.
+:::
 
 ## Storing a backup of the data as a batch file
 
+<!-- TODO: I'm not sure how effective this workflow is, we'll assess as we use it -->
+
 ::: callout-note
-See the [flow diagrams](/docs/design/interface/flows.qmd#flows) for a
-simplified flow of steps involved in adding batch files.
+See the [flow diagrams](/docs/design/interface/flows.qmd) for a
+simplified flow of steps involved in adding batch files. Also see the
+[design docs](/docs/design/interface/outputs.qmd) for why we include
+these batch files in the resource's folder.
 :::
 
 Batch files are used to store data in a data package each time you add
-data to a resource. These batch files will be used to create the data
-file that is actually used as the resource at the path
-`resource/<name>/data.parquet`. The first time a batch file is saved, it
-will create the folders necessary for the resource.
+new or modified data to a resource. These batch files will be used to
+create the final data file that is actually used as the resource at the
+path `resource/<name>/data.parquet`. The first time a batch file is
+saved, it will create the folders necessary for the resource.
 
-As shown above, the data is currently stored loaded as a Polars
-DataFrame called `data`. Now, it's time to store this data in the
-resource's folder by using:
-
-<!-- TODO: Convert to save to temp location -->
+As shown above, the data is currently loaded as a Polars DataFrame
+called `raw_data_patients`. Now, it's time to store this data in the
+resource's folder by using the `write_resource_batch()` function in the
+`main.py` file.
 
 ```{python}
+#| filename: "main.py"
+#| eval: false
+# This code is shortened to only show what was changed.
+# Add this to the imports.
+from scripts.resource_properties_patients import resource_properties_patients
+
+def main():
+    # Previous code is excluded to keep it short.
+    # New code inserted to the bottom -----
+    # Save the batch data.
+    sp.write_resource_batch(
+        data=raw_data_patients,
+        resource_properties=resource_properties_patients
+    )
+```
+
+```{python}
+#| include: false
+# Only to check that it runs.
 sp.write_resource_batch(
     data=raw_data_patients,
     resource_properties=resource_properties_patients,
+    package_path=package_path.root()
 )
 ```
 
 This function uses the properties object to determine where to store the
 data as a batch file, which is in the `batch/` folder of the resource's
 folder. If this is the first time adding a batch file, all the folders
-will be set up. You can check the newly added file by using:
+will be set up. So the file structure should look like this now:
 
 ```{python}
-print(package_path.resource_batch_files(1))
+print(file_tree(package_path.root()))
 ```
 
 ## Building the resource data file
 
 Now that you've stored the data as a batch file, you can build the
-Parquet file that will be used as the data resource. This Parquet file
-is built from all the data in the `batch/` folder. Since there is only
-one batch data file stored in the resource's folder, only this one will
-be used to build the data resource's Parquet file:
+`resource/<name>/data.parquet` file that will be used as the data
+resource. This Parquet file is built from all the data in the `batch/`
+folder. Since there is only one batch data file stored in the resource's
+folder, only this one will be used to build the data resource's Parquet
+file. Before you can create this main Parquet file, you need to read in
+all the batch files, join them together, and, optionally, do any
+additional processing on the data before writing it to the file. The
+functions are `read_resource_batches()`, `join_resource_batches()`, and
+`write_resource_data()`. Several of these functions will internally run
+checks via `check_data()`.
+
+Let's add these functions to the `main.py` file to make the
+`data.parquet` file:
 
 ```{python}
+#| filename: "main.py"
 #| eval: false
-# TODO: eval when function implemented
-sp.join_resource_batches(
-    data_list=...,
-    resource_properties=resource_properties
-)
-```
-
-::: callout-tip
-If you add more data to the resource later on, you can update this
-Parquet file to include all data in the batch folder using the
-`build_resource_parquet()` function like shown above.
-:::
-
-## Re-building the README file
-
-One of the last steps to adding a new data resource is to re-build the
-`README.md` file of the data package. To allow some flexibility with
-what gets added to the README text, this next function will only *build
-the text*, but not write it to the file. This allows you to add
-additional information to the README text before writing it to the file.
-
-```{python}
-readme_text = sp.as_readme_text(
-    properties=sp.read_properties(package_path.properties())
-)
-```
-
-For this guide, you'll only use the default text and not add anything
-else to it. Next you write the text to the `README.md` file by:
-
-```{python}
-sp.write_file(
-    string=readme_text,
-    path=package_path.readme()
-)
-```
-
-## Updating resource properties
-
-After having created a resource, you may need to make edits to the
-properties. While technically you can do this manually by opening up the
-`datapackage.json` file and editing it, we strongly recommend you use
-the update functions to do this. These functions help to ensure that the
-`datapackage.json` file is still in a correct JSON format and has the
-correct fields filled in. You can call the
-`update_resource_properties()` function with two arguments: the current
-resource properties and a resource properties object representing the
-updates you want to make. This latter object will very often be a
-partial resource properties, in the sense that it will have only those
-fields filled in that you want to update. The function will return an
-updated resource properties object. Any field in the object representing
-the updates will overwrite the corresponding field in the current
-properties object.
-
-```{python}
-#| eval: false
-# TODO: eval when function implemented
-resource_properties = sp.update_resource_properties(
-    current_properties=resource_properties,
-    update_properties=sp.ResourceProperties(
-        title="Basic characteristics of patients"
+# This code is shortened to only show what was changed.
+def main():
+    # Previous code is excluded to keep it short.
+    # New code inserted to the bottom -----
+    # Read in all the batch data files for the resource as a list.
+    batch_data = sp.read_resource_batches(
+        resource_properties=resource_properties_patients
     )
-)
-pprint(resource_properties)
-```
-
-Finally, to write your changes back to `datapackage.json`, use the
-`write_properties()` function:
-
-```{python}
-#| eval: false
-# TODO: Update to use template when it has been implemented
-sp.write_properties(
-    properties=properties,
-    path=package_path.properties(),
-)
+    # Join them all together into a single Polars DataFrame.
+    joined_data = sp.join_resource_batches(
+        data_list=batch_data,
+        resource_properties=resource_properties_patients
+    )
+    sp.write_resource_data(
+        data=joined_data,
+        resource_properties=resource_properties_patients
+    )
 ```
 
 ```{python}
 #| include: false
-import shutil
+# Just to check that it runs.
+batch_data = sp.read_resource_batches(
+    resource_properties=resource_properties_patients,
+    paths=package_path.resource_batch_files("patients")
+)
+joined_data = sp.join_resource_batches(
+    data_list=batch_data,
+    resource_properties=resource_properties_patients
+)
+sp.write_resource_data(
+    data=joined_data,
+    resource_properties=resource_properties_patients,
+    package_path=package_path.root()
+)
+```
 
-if Path(temp_path.name).exists():
-    shutil.rmtree(Path(temp_path.name))
+::: callout-tip
+If you add more data to the resource later on as more batch files, you
+can update this main `data.parquet` file to include the updated data in
+the batch folder using this same workflow.
+:::
+
+Now the file structure should look like this:
+
+```{python}
+#| echo: false
+print(file_tree(package_path.root()))
+```
+
+```{python}
+#| include: false
+temp_path.cleanup()
 ```

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -37,6 +37,8 @@ structure used by Sprout are:
     `update_resource_properties()` and then write the result to the
     `datapackage.json` file.
 
+{{< include _python-minimal-package-setup.qmd >}}
+
 ```{python setup}
 #| include: false
 # This `setup` code chunk creates a package and downloads some data.


### PR DESCRIPTION
# Description

Updates the resource guide to be executable and to implement the template workflow. 

I also moved out some of the initial setup steps (including the `file_tree()`)  into a separate `.qmd` file, so it's easy to reuse across guides. 

Closes #1315
Closes #1197

This PR needs an in-depth review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
