### PR TITLE
build: :fire: don't need warning about docs being "experimental"

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -15,12 +15,6 @@ website:
   site-url: "https://sprout.seedcase-project.org/"
   repo-url: "https://github.com/seedcase-project/seedcase-sprout"
   page-navigation: true
-  body-header: |
-    ::: {.callout-warning appearance="default" icon="true"}
-    🚧 Sprout is still in active development and evolving quickly, so the
-    documentation and functionality may not work as described
-    and could undergo substantial changes 🚧
-    :::
   navbar:
     pinned: true
     title: false


### PR DESCRIPTION
# Description

We will soon publish to pypi, so we don't need this warning anymore.

No review needed.
