### PR TITLE
fix: :bug: dedent `description` in `as_readme_text()` and `write_properties()`

### DIFF
--- a/src/seedcase_sprout/as_readme_text.py
+++ b/src/seedcase_sprout/as_readme_text.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
 
 from seedcase_sprout.constants import TEMPLATES_PATH
-from seedcase_sprout.internals import _to_dedented_text
+from seedcase_sprout.internals import _to_dedented
 from seedcase_sprout.properties import (
     LicenseProperties,
     PackageProperties,
@@ -33,7 +33,7 @@ def as_readme_text(properties: PackageProperties) -> str:
 
     # Dedent description text.
     if properties.description:
-        properties.description = _to_dedented_text(properties.description)
+        properties.description = _to_dedented(properties.description)
 
     return template.render(properties=properties)
 

--- a/src/seedcase_sprout/as_readme_text.py
+++ b/src/seedcase_sprout/as_readme_text.py
@@ -1,9 +1,9 @@
-import re
 from datetime import datetime
 
 from jinja2 import Environment, FileSystemLoader
 
 from seedcase_sprout.constants import TEMPLATES_PATH
+from seedcase_sprout.internals import _to_dedented_text
 from seedcase_sprout.properties import (
     LicenseProperties,
     PackageProperties,
@@ -33,25 +33,9 @@ def as_readme_text(properties: PackageProperties) -> str:
 
     # Dedent description text.
     if properties.description:
-        properties.description = _dedent_text(properties.description)
+        properties.description = _to_dedented_text(properties.description)
 
     return template.render(properties=properties)
-
-
-def _dedent_text(text: str) -> str:
-    """Dedent text.
-
-    If text is not indented, it will be returned as is. If it is indented, the leading
-    whitespace or tab will be removed from each line.
-
-    Args:
-        text: The text string to dedent.
-
-    Returns:
-        The string dedented.
-    """
-    # Remove leading whitespace or tab from each line.
-    return re.sub(r"^[ \t]+", "", text, flags=re.MULTILINE)
 
 
 def _join_names(licenses: list[LicenseProperties] | None) -> str:

--- a/src/seedcase_sprout/as_readme_text.py
+++ b/src/seedcase_sprout/as_readme_text.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 
 from jinja2 import Environment, FileSystemLoader
@@ -29,7 +30,28 @@ def as_readme_text(properties: PackageProperties) -> str:
     env.filters["inline_code"] = _inline_code
     env.filters["format_link"] = _format_link
     template = env.get_template("README.jinja2")
+
+    # Dedent description text.
+    if properties.description:
+        properties.description = _dedent_text(properties.description)
+
     return template.render(properties=properties)
+
+
+def _dedent_text(text: str) -> str:
+    """Dedent text.
+
+    If text is not indented, it will be returned as is. If it is indented, the leading
+    whitespace or tab will be removed from each line.
+
+    Args:
+        text: The text string to dedent.
+
+    Returns:
+        The string dedented.
+    """
+    # Remove leading whitespace or tab from each line.
+    return re.sub(r"^[ \t]+", "", text, flags=re.MULTILINE)
 
 
 def _join_names(licenses: list[LicenseProperties] | None) -> str:

--- a/src/seedcase_sprout/internals/__init__.py
+++ b/src/seedcase_sprout/internals/__init__.py
@@ -8,7 +8,7 @@ from .create import (
 from .functionals import _map, _map2
 from .get import _get_iso_timestamp, _get_nested_attr
 from .read import _read_json
-from .to import _to_camel_case, _to_snake_case
+from .to import _to_camel_case, _to_dedented_text, _to_snake_case
 from .write import _write_json
 
 __all__ = [
@@ -24,4 +24,5 @@ __all__ = [
     "_read_json",
     "_write_json",
     "_to_camel_case",
+    "_to_dedented_text",
 ]

--- a/src/seedcase_sprout/internals/__init__.py
+++ b/src/seedcase_sprout/internals/__init__.py
@@ -8,7 +8,7 @@ from .create import (
 from .functionals import _map, _map2
 from .get import _get_iso_timestamp, _get_nested_attr
 from .read import _read_json
-from .to import _to_camel_case, _to_dedented_text, _to_snake_case
+from .to import _to_camel_case, _to_dedented, _to_snake_case
 from .write import _write_json
 
 __all__ = [
@@ -24,5 +24,5 @@ __all__ = [
     "_read_json",
     "_write_json",
     "_to_camel_case",
-    "_to_dedented_text",
+    "_to_dedented",
 ]

--- a/src/seedcase_sprout/internals/to.py
+++ b/src/seedcase_sprout/internals/to.py
@@ -1,3 +1,6 @@
+import re
+
+
 def _to_snake_case(name: str) -> str:
     """Creates a snake-case version of a package or resource name.
 
@@ -22,3 +25,21 @@ def _to_camel_case(text: str) -> str:
     """
     first_part, *remaining_parts = text.split("_")
     return first_part + "".join(part.title() for part in remaining_parts)
+
+
+def _to_dedented_text(text: str) -> str:
+    """Dedents text by removing leading whitespace and tabs from each line.
+
+    If it is not indented, it will be returned as is.
+    If the first line starts with newlines, those will be removed.
+
+    Args:
+        text: The text to dedent.
+
+    Returns:
+        The dedented text.
+    """
+    # Remove leading whitespace or tabs from each line
+    dedented = re.sub(r"^[ \t]+", "", text, flags=re.MULTILINE)
+    # Remove leading newlines from the very start
+    return dedented.lstrip("\n")

--- a/src/seedcase_sprout/internals/to.py
+++ b/src/seedcase_sprout/internals/to.py
@@ -27,7 +27,7 @@ def _to_camel_case(text: str) -> str:
     return first_part + "".join(part.title() for part in remaining_parts)
 
 
-def _to_dedented_text(text: str) -> str:
+def _to_dedented(text: str) -> str:
     """Dedents text by removing leading whitespace and tabs from each line.
 
     If it is not indented, it will be returned as is.

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from seedcase_sprout.check_properties import check_properties
-from seedcase_sprout.internals import _to_dedented_text, _write_json
+from seedcase_sprout.internals import _to_dedented, _write_json
 from seedcase_sprout.paths import PackagePath
 from seedcase_sprout.properties import PackageProperties
 
@@ -26,6 +26,6 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
     """
     path = path or PackagePath().properties()
     if properties.description:
-        properties.description = _to_dedented_text(properties.description)
+        properties.description = _to_dedented(properties.description)
     check_properties(properties)
     return _write_json(properties.compact_dict, path)

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from seedcase_sprout.check_properties import check_properties
-from seedcase_sprout.internals import _write_json
+from seedcase_sprout.internals import _to_dedented_text, _write_json
 from seedcase_sprout.paths import PackagePath
 from seedcase_sprout.properties import PackageProperties
 
@@ -25,5 +25,6 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
             `CheckError`s, one error for each failed check.
     """
     path = path or PackagePath().properties()
+    properties.description = _to_dedented_text(properties.description or "")
     check_properties(properties)
     return _write_json(properties.compact_dict, path)

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -25,6 +25,7 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
             `CheckError`s, one error for each failed check.
     """
     path = path or PackagePath().properties()
-    properties.description = _to_dedented_text(properties.description or "")
+    if properties.description:
+        properties.description = _to_dedented_text(properties.description)
     check_properties(properties)
     return _write_json(properties.compact_dict, path)

--- a/tests/test_as_readme_text.py
+++ b/tests/test_as_readme_text.py
@@ -59,17 +59,17 @@ def test_creates_readme_with_empty_values():
 @mark.parametrize(
     "description, expected",
     [
-        # Empty or whitespace-only
+        # Empty or whitespace-only.
         ("", ""),
         ("    ", ""),
-        # Single line text
+        # Single line text.
         ("Non-indented one-line text.", "Non-indented one-line text."),
         ("    Indented one-line text.", "Indented one-line text."),
         (
             "    Indented one-line text with trailing whitespace.   ",
             "Indented one-line text with trailing whitespace.",
         ),
-        # Multiline text
+        # Multiline text.
         ("Non-indented\nmultiline\ntext.", "Non-indented\nmultiline\ntext."),
         ("    Indented\n    multiline text.", "Indented\nmultiline text."),
         (
@@ -84,7 +84,7 @@ def test_creates_readme_with_empty_values():
             """,
             "Indented multiline\ntext",
         ),
-        # Mixed indentation
+        # Mixed indentation.
         (
             "\tIndented with tab\n    Indented with spaces\n\t  Mixed indented line",
             "Indented with tab\nIndented with spaces\nMixed indented line",

--- a/tests/test_as_readme_text.py
+++ b/tests/test_as_readme_text.py
@@ -73,9 +73,9 @@ def test_creates_readme_with_empty_values():
         ("Non-indented\nmultiline\ntext.", "Non-indented\nmultiline\ntext."),
         ("    Indented\n    multiline text.", "Indented\nmultiline text."),
         (
-            """Indented multiline
-        text.""",
-            "Indented multiline\ntext.",
+            """Non-indented first line,
+            indented second line.""",
+            "Non-indented first line,\nindented second line.",
         ),
         (
             """

--- a/tests/test_as_readme_text.py
+++ b/tests/test_as_readme_text.py
@@ -84,6 +84,11 @@ def test_creates_readme_with_empty_values():
             """,
             "Indented multiline\ntext",
         ),
+        # Tab indentation.
+        (
+            "\tIndented with tab\n\tAlso indented with tab",
+            "Indented with tab\nAlso indented with tab",
+        ),
         # Mixed indentation.
         (
             "\tIndented with tab\n    Indented with spaces\n\t  Mixed indented line",
@@ -92,6 +97,14 @@ def test_creates_readme_with_empty_values():
         (
             "  Indented with 2 spaces\n    Indented with 4 spaces\n  Back to 2 spaces",
             "Indented with 2 spaces\nIndented with 4 spaces\nBack to 2 spaces",
+        ),
+        # Multi-level list (relative indentation removed, not ideal).
+        (
+            """
+            Description with multilevel list:
+            - Item 1
+                - Item 2""",
+            "Description with multilevel list:\n- Item 1\n- Item 2",
         ),
     ],
 )

--- a/tests/test_as_readme_text.py
+++ b/tests/test_as_readme_text.py
@@ -1,3 +1,5 @@
+from pytest import mark
+
 from seedcase_sprout import (
     ContributorProperties,
     LicenseProperties,
@@ -52,3 +54,53 @@ def test_creates_readme():
 def test_creates_readme_with_empty_values():
     """Should be able to create a README for an empty set of properties."""
     assert as_readme_text(PackageProperties())
+
+
+@mark.parametrize(
+    "description, expected",
+    [
+        # Empty or whitespace-only
+        ("", ""),
+        ("    ", ""),
+        # Single line text
+        ("Non-indented one-line text.", "Non-indented one-line text."),
+        ("    Indented one-line text.", "Indented one-line text."),
+        (
+            "    Indented one-line text with trailing whitespace.   ",
+            "Indented one-line text with trailing whitespace.",
+        ),
+        # Multiline text
+        ("Non-indented\nmultiline\ntext.", "Non-indented\nmultiline\ntext."),
+        ("    Indented\n    multiline text.", "Indented\nmultiline text."),
+        (
+            """Indented multiline
+        text.""",
+            "Indented multiline\ntext.",
+        ),
+        (
+            """
+            Indented multiline
+            text
+            """,
+            "Indented multiline\ntext",
+        ),
+        # Mixed indentation
+        (
+            "\tIndented with tab\n    Indented with spaces\n\t  Mixed indented line",
+            "Indented with tab\nIndented with spaces\nMixed indented line",
+        ),
+        (
+            "  Indented with 2 spaces\n    Indented with 4 spaces\n  Back to 2 spaces",
+            "Indented with 2 spaces\nIndented with 4 spaces\nBack to 2 spaces",
+        ),
+    ],
+)
+def test_dedents_multiline_description(description, expected):
+    """Should be able to dedent description."""
+    properties = PackageProperties(
+        name="diabetes-hypertension-study",
+        description=description,
+    )
+
+    readme_text = as_readme_text(properties)
+    assert expected in readme_text

--- a/tests/test_as_readme_text.py
+++ b/tests/test_as_readme_text.py
@@ -67,7 +67,7 @@ def test_creates_readme_with_empty_values():
         ("    Indented one-line text.", "Indented one-line text."),
         (
             "    Indented one-line text with trailing whitespace.   ",
-            "Indented one-line text with trailing whitespace.",
+            "Indented one-line text with trailing whitespace.   ",
         ),
         # Multiline text.
         ("Non-indented\nmultiline\ntext.", "Non-indented\nmultiline\ntext."),

--- a/tests/test_write_properties.py
+++ b/tests/test_write_properties.py
@@ -94,5 +94,5 @@ def test_writes_properties_with_dedented_description(path, properties):
     assert (
         # json.dumps() adds the extra `\` to escape the `\n` in the string.
         "Indented description with leading spaces.\\nMultiline text with tab and space."
-        in path.read_bytes().decode("utf-8")
+        in path.read_text()
     )

--- a/tests/test_write_properties.py
+++ b/tests/test_write_properties.py
@@ -79,3 +79,20 @@ def test_throws_error_if_error_in_resource_properties(path, properties):
 def test_writes_properties_to_cwd_if_no_path_provided(tmp_cwd, properties):
     """If no path is provided, should use datapackage.json in the cwd."""
     assert write_properties(properties) == PackagePath(tmp_cwd).properties()
+
+
+def test_writes_properties_with_dedented_description(path, properties):
+    """Should write properties to file with dedented description."""
+    # Simple test here bc it's tested thoroughly in the `as_readme_text` tests.
+    properties.description = """
+        Indented description with leading spaces.
+        \t Multiline text with tab and space.
+        """
+
+    write_properties(properties, path)
+
+    assert (
+        # json.dumps() adds the extra `\` to escape the `\n` in the string.
+        "Indented description with leading spaces.\\nMultiline text with tab and space."
+        in path.read_bytes().decode("utf-8")
+    )


### PR DESCRIPTION
# Description

This PR adds an internal function `_to_dedented_text()` that's used in `as_readme_text()` and `write_properties()` to dedent the `PackageProperties.description` in case it's indented. This way, the description text isn't indented in `datapackage.json` and `README.md`. 

See issue below for example.

Closes #1475 

This PR needs an in-depth review.

## Checklist

- [X] Added or updated tests
- [ ] Ran `just run-all`
