### PR TITLE
 refactor: 🚚 rename obj in package properties script to `package_properties`

### DIFF
--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -69,7 +69,7 @@ uv run main.py
 sp.create_properties_script(package_path.root())
 ```
 
-This will create a `properties.py` file in the newly created `scripts/`
+This will create a `package_properties.py` file in the newly created `scripts/`
 folder of your data package.
 
 ::: callout-caution
@@ -97,7 +97,7 @@ The file structure should now look like:
 print(file_tree(package_path.root()))
 ```
 
-Inside the `scripts/properties.py` file, you will find a template for
+Inside the `scripts/package_properties.py` file, you will find a template for
 creating the properties of your data package. It looks like:
 
 ```{python}
@@ -126,7 +126,7 @@ is an example of a set of properties with required fields filled in
 
 ```{python}
 #| eval: false
-properties = sp.PackageProperties(
+package_properties = sp.PackageProperties(
     name="diabetes-study",
     title="A Study on Diabetes",
     # You can write Markdown below, with the helper `sp.dedent()`.
@@ -175,13 +175,13 @@ So in your `main.py`, include this code:
 #| eval: false
 #| filename: "main.py"
 import seedcase_sprout as sp
-from scripts.properties import properties
+from scripts.package_properties import package_properties
 
 def main():
     # Create the properties script in default location.
     sp.create_properties_script()
     # Write properties from properties script to `datapackage.json`.
-    sp.write_properties(properties=properties)
+    sp.write_properties(properties=package_properties)
 
 if __name__ == "__main__":
     main()
@@ -207,7 +207,7 @@ The `write_properties()` function will give an error if the
 `PackageProperties` object is missing some of its required fields or if
 they are not filled in correctly. In that case, a `datapackage.json`
 file won't be created. So you will have to return to the
-`scripts/properties.py` file and fill in the correct properties.
+`scripts/package_properties.py` file and fill in the correct properties.
 :::
 
 The `write_properties()` function created the `datapackage.json` file in
@@ -233,15 +233,15 @@ data package you just created by writing it in the `main.py` file.
 #| eval: false
 #| filename: "main.py"
 import seedcase_sprout as sp
-from scripts.properties import properties
+from scripts.package_properties import package_properties
 
 def main():
     # Create the properties script in default location.
     sp.create_properties_script()
     # Save the properties to `datapackage.json`.
-    sp.write_properties(properties=properties)
+    sp.write_properties(properties=package_properties)
     # Create text for a README of the data package.
-    readme_text = sp.as_readme_text(properties)
+    readme_text = sp.as_readme_text(package_properties)
     # Write the README text to a `README.md` file.
     sp.write_file(readme_text, sp.PackagePath().readme())
 

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -161,7 +161,7 @@ the creation of our resource properties script:
 #| filename: "main.py"
 #| eval: false
 import seedcase_sprout as sp
-from scripts.properties import properties
+from scripts.package_properties import package_properties
 import polars as pl
 
 def main():
@@ -184,9 +184,9 @@ def main():
     # New code ends here -----
 
     # Save the properties to `datapackage.json`.
-    sp.write_properties(properties=properties)
+    sp.write_properties(properties=package_properties)
     # Create text for a README of the data package.
-    readme_text = sp.as_readme_text(properties)
+    readme_text = sp.as_readme_text(package_properties)
     # Write the README text to a `README.md` file.
     sp.write_file(readme_text, sp.PackagePath().readme())
 
@@ -353,11 +353,11 @@ package. You can do this by adding the following lines to the
 
 ```{python}
 #| eval: false
-#| filename: "properties.py"
+#| filename: "package_properties.py"
 # Import the resource properties object.
 from .resource_properties_patients import resource_properties_patients
 
-properties = sp.PackageProperties(
+package_properties = sp.PackageProperties(
     # Your existing properties here...
     resources=[
         resource_properties_patients,
@@ -372,8 +372,8 @@ resource.
 
 The next step is to write the resource properties to the
 `datapackage.json` file. Since we included the `resource_properties`
-object directly into the `scripts/properties.py` file, and since the
-`scripts/properties.py` file is imported already in `main.py`, we can
+object directly into the `scripts/package_properties.py` file, and since the
+`scripts/package_properties.py` file is imported already in `main.py`, we can
 simply re-run the `main.py` file and it will update both the
 `datapackage.json` file and the `README.md` file.
 

--- a/src/seedcase_sprout/templates/package_properties.py.jinja2
+++ b/src/seedcase_sprout/templates/package_properties.py.jinja2
@@ -2,7 +2,7 @@ import seedcase_sprout as sp
 
 # from .resource_properties import resource_properties
 
-properties = sp.PackageProperties(
+package_properties = sp.PackageProperties(
     ## Required:
     name="{{ properties.name }}",
     title="",

--- a/tests/test_create_properties_script.py
+++ b/tests/test_create_properties_script.py
@@ -19,7 +19,7 @@ def test_creates_script_with_default_values(mock_uuid, tmp_cwd):
     script_path = create_properties_script()
 
     assert script_path == PackagePath().properties_script()
-    properties = load_properties(script_path, "properties")
+    properties = load_properties(script_path, "package_properties")
     assert properties == PackageProperties(
         name=tmp_cwd.name,
         title="",
@@ -36,7 +36,9 @@ def test_works_with_custom_path(tmp_path):
     script_path = create_properties_script(tmp_path)
 
     assert script_path == PackagePath(tmp_path).properties_script()
-    properties = cast(PackageProperties, load_properties(script_path, "properties"))
+    properties = cast(
+        PackageProperties, load_properties(script_path, "package_properties")
+    )
     assert properties.name == tmp_path.name
 
 


### PR DESCRIPTION
# Description

When I renamed the template, I forgot to rename the `PackageProperties` object in it to match. This PR does that. 

This PR needs a quick review.

## Checklist

- [X] Added or updated tests
- [X] Ran `just run-all`
