### PR TITLE
feat: :sparkles: dedent resource and field descriptions in `write_properties()`

### DIFF
--- a/src/seedcase_sprout/internals/to.py
+++ b/src/seedcase_sprout/internals/to.py
@@ -27,7 +27,7 @@ def _to_camel_case(text: str) -> str:
     return first_part + "".join(part.title() for part in remaining_parts)
 
 
-def _to_dedented(text: str) -> str:
+def _to_dedented(text: str | None) -> str | None:
     """Dedents text by removing leading whitespace and tabs from each line.
 
     If it is not indented, it will be returned as is.
@@ -37,8 +37,11 @@ def _to_dedented(text: str) -> str:
         text: The text to dedent.
 
     Returns:
-        The dedented text.
+        The dedented text or `None` if the input is `None`.
     """
+    if text is None:
+        return None
+
     # Remove leading whitespace or tabs from each line
     dedented = re.sub(r"^[ \t]+", "", text, flags=re.MULTILINE)
     # Remove leading newlines from the very start

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -32,8 +32,7 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
     path = path or PackagePath().properties()
 
     # Dedent descriptions
-    if properties.description:
-        properties.description = _to_dedented(properties.description)
+    properties.description = _to_dedented(properties.description)
 
     # TODO: Code to find all description fields and dedent to avoid nested for-loops?
     for resource in properties.resources or []:

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -1,12 +1,13 @@
 from pathlib import Path
+from typing import cast
 
 from seedcase_sprout.check_properties import check_properties
 from seedcase_sprout.internals import _to_dedented, _write_json
+from seedcase_sprout.internals.get import _get_nested_attr
 from seedcase_sprout.paths import PackagePath
 from seedcase_sprout.properties import (
     FieldProperties,
     PackageProperties,
-    ResourceProperties,
 )
 
 
@@ -29,26 +30,20 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
             `CheckError`s, one error for each failed check.
     """
     path = path or PackagePath().properties()
+
+    # Dedent descriptions
     if properties.description:
         properties.description = _to_dedented(properties.description)
 
-    resources = getattr(properties, "resources", None)
-    if resources:
-        for resource in resources:
-            _dedent_if_present(resource, "description")
+    for resource in properties.resources or []:
+        resource.description = _to_dedented(resource.description)
 
-            schema = getattr(resource, "schema", None)
-            if schema and schema.fields:
-                for field in schema.fields:
-                    _dedent_if_present(field, "description")
+        for field in cast(
+            list[FieldProperties],
+            _get_nested_attr(resource, "schema.fields", default=[]),
+        ):
+            field.description = _to_dedented(field.description)
 
     check_properties(properties)
+
     return _write_json(properties.compact_dict, path)
-
-
-def _dedent_if_present(
-    properties: ResourceProperties | FieldProperties, field: str
-) -> None:
-    val = getattr(properties, field, None)
-    if val:
-        setattr(properties, field, _to_dedented(val))

--- a/src/seedcase_sprout/write_properties.py
+++ b/src/seedcase_sprout/write_properties.py
@@ -35,6 +35,7 @@ def write_properties(properties: PackageProperties, path: Path | None = None) ->
     if properties.description:
         properties.description = _to_dedented(properties.description)
 
+    # TODO: Code to find all description fields and dedent to avoid nested for-loops?
     for resource in properties.resources or []:
         resource.description = _to_dedented(resource.description)
 

--- a/tests/test_write_properties.py
+++ b/tests/test_write_properties.py
@@ -81,18 +81,22 @@ def test_writes_properties_to_cwd_if_no_path_provided(tmp_cwd, properties):
     assert write_properties(properties) == PackagePath(tmp_cwd).properties()
 
 
-def test_writes_properties_with_dedented_description(path, properties):
+def test_writes_properties_with_dedented_descriptions(path, properties):
     """Should write properties to file with dedented description."""
     # Simple test here bc it's tested thoroughly in the `as_readme_text` tests.
-    properties.description = """
+    indented_text = """
         Indented description with leading spaces.
         \t Multiline text with tab and space.
         """
 
+    properties.description = indented_text
+    properties.resources[0].description = indented_text
+    properties.resources[0].schema.fields[0].description = indented_text
+
     write_properties(properties, path)
 
-    assert (
-        # json.dumps() adds the extra `\` to escape the `\n` in the string.
+    dedented_text = (
         "Indented description with leading spaces.\\nMultiline text with tab and space."
-        in path.read_text()
     )
+    file_text = path.read_text()
+    assert file_text.count(dedented_text) == 3

--- a/tests/test_write_properties.py
+++ b/tests/test_write_properties.py
@@ -100,3 +100,20 @@ def test_writes_properties_with_dedented_descriptions(path, properties):
     )
     file_text = path.read_text()
     assert file_text.count(dedented_text) == 3
+
+
+def test_throws_error_if_resource_description_is_none(path, properties):
+    """Should throw an error if the required resource description is None, i.e.,
+    dedentation works and the subsequent check fails."""
+    properties.resources[0].description = None
+
+    with raises(ExceptionGroup):
+        write_properties(properties, path)
+
+
+def test_writes_properties_when_field_description_is_none(path, properties):
+    """Should write properties to file without optional field description."""
+    properties.resources[0].schema.fields[0].description = None
+    write_properties(properties, path)
+
+    assert_file_contains(path, properties)


### PR DESCRIPTION
# Description

Following the work in #1476 and in `example_seed_beetle`, we've seen that the resource and field descriptions get indented in the `datapackage.json` as well.

These changes dedent them as well.

This PR needs an in-depth review.

## Checklist

- [X] Added or updated tests
- [X] Ran `just run-all`
