### PR TITLE
docs: :pencil2: fix badge quality by using `svg` instead of `png`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15800477.svg)](https://doi.org/10.5281/zenodo.15800477)
 [![GitHub
-License](https://img.shields.io/github/license/seedcase-project/seedcase-sprout.png)](https://github.com/seedcase-project/seedcase-sprout/blob/main/LICENSE.md)
+License](https://img.shields.io/github/license/seedcase-project/seedcase-sprout.svg)](https://github.com/seedcase-project/seedcase-sprout/blob/main/LICENSE.md)
 [![PyPI
-Version](https://img.shields.io/pypi/v/seedcase-sprout.png)](https://pypi.org/project/seedcase-sprout/)
+Version](https://img.shields.io/pypi/v/seedcase-sprout.svg)](https://pypi.org/project/seedcase-sprout)
 [![GitHub
-Release](https://img.shields.io/github/v/release/seedcase-project/seedcase-sprout.png)](https://github.com/seedcase-project/seedcase-sprout/releases/latest)
+Release](https://img.shields.io/github/v/release/seedcase-project/seedcase-sprout.svg)](https://github.com/seedcase-project/seedcase-sprout/releases/latest)
 [![Supported Python Version from PEP 621
 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fseedcase-project%2Fseedcase-sprout%2Frefs%2Fheads%2Fmain%2Fpyproject.toml)](https://github.com/seedcase-project/seedcase-sprout/blob/main/pyproject.toml)
 [![OpenSSF


### PR DESCRIPTION
# Description

The badges for license, PyPI and release has a lower quality currently:

<img width="1271" height="226" alt="image" src="https://github.com/user-attachments/assets/b98362c7-9aab-4337-930c-220c31b0dbc0" />

I fixed this by changing them to `svg` instead. For some reason, these three were `png`s. 

They now look like this when I render locally ✨ 💅:

<img width="1357" height="323" alt="image" src="https://github.com/user-attachments/assets/62732328-0e4a-4244-bc41-20edab766401" />


This PR needs a quick review.

## Checklist

- [X] Updated documentation
- [X] Ran `just run-all`
