### PR TITLE
docs: :memo: deduplicate callout

### DIFF
--- a/docs/design/index.qmd
+++ b/docs/design/index.qmd
@@ -54,7 +54,7 @@ Overall, Sprout must:
 
 -   Be able to handle a variety of data file sizes: While the size of
     research data usually does not compare to that found in industry,
-    Sprout must be able to handle data that is large enough to requires
+    Sprout must be able to handle data that is large enough to require
     special care and handling.
 -   Store data in a format that is open source, integrates with many
     tools, and is storage efficient: Sprout is first and foremost a data

--- a/docs/guide/index.qmd
+++ b/docs/guide/index.qmd
@@ -8,3 +8,5 @@ listing:
     fields:
         - title
 ---
+
+{{< include _preamble.qmd >}}

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -3,8 +3,6 @@ title: "Installing Sprout"
 order: 0
 ---
 
-{{< include _preamble.qmd >}}
-
 Before installing Sprout, you need to have
 [Python](https://www.python.org/downloads/) and
 [pipx](https://pipx.pypa.io/latest/installation/) installed.

--- a/docs/guide/packages.qmd
+++ b/docs/guide/packages.qmd
@@ -8,8 +8,6 @@ At the core of Sprout is the ["data package"](/docs/glossary.qmd), which
 is a standardized way of structuring and documenting data. This guide
 will show you how to create and manage data packages using Sprout.
 
-{{< include _preamble.qmd >}}
-
 {{< include _python-minimal-package-setup.qmd >}}
 
 ## Creating a data package

--- a/docs/guide/resources.qmd
+++ b/docs/guide/resources.qmd
@@ -10,8 +10,6 @@ of data. This page shows you how to use Sprout to create and manage data
 resources inside a data package. You will need to have [created a data
 package](packages.qmd#creating-a-data-package) already.
 
-{{< include _preamble.qmd >}}
-
 ::: callout-important
 Data resources can only be created from [tidy
 data](https://design.seedcase-project.org/data/) in [Polars


### PR DESCRIPTION
# Description

Only have the callout in one place: the guide landing page. That landing page now looks like this:

<img width="1115" height="783" alt="image" src="https://github.com/user-attachments/assets/7fdd6a83-1af5-4576-ab73-481a2f4e2828" />

Closes https://github.com/seedcase-project/seedcase-sprout/issues/1571

Needs a quick review.

## Checklist

- [x] Formatted Markdown
- [ ] Ran `just run-all`
