### PR TITLE
docs: :memo: clarify and contextualize installation steps

### DIFF
--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -3,19 +3,19 @@ title: "Installing Sprout"
 order: 0
 ---
 
-Before installing Sprout, you need to have
-[Python](https://www.python.org/downloads/) and
-[pipx](https://pipx.pypa.io/latest/installation/) installed.
+{{< include _preamble.qmd >}}
+
+Before installing Sprout, you need to have [Python](https://www.python.org/downloads/) and a Python package manager installed. For the latter, we recommend using uv which can be [installed via a shell script](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) or [via pipx](https://docs.astral.sh/uv/getting-started/installation/#pypi).
 
 To check that these programs are installed, run the following commands
 in your Terminal:
 
 ``` {.bash filename="Terminal"}
 python3 --version
-pipx --version
+uv --version
 ```
 
-If Python and pipx are installed, these commands will show you the
+If Python and uv are installed, these commands will show you the
 versions installed on your system. If you get an error, you need to
 install them before continuing.
 
@@ -27,19 +27,6 @@ system-wide Python setup and avoid conflicts. There are several tools to
 manage package dependencies and create virtual environments, such as
 venv, virtualenv, and uv. For this guide, we will use
 [uv](https://docs.astral.sh/uv/).
-
-If you don't have uv installed, you can install it in your Terminal with
-pipx:
-
-``` {.bash filename="Terminal"}
-pipx install uv
-```
-
-To check that uv is installed, run this command:
-
-``` {.bash filename="Terminal"}
-uv
-```
 
 You can create a Python project using [uv](https://docs.astral.sh/uv/).
 In short, you can create a new project using uv by running the following

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -3,8 +3,6 @@ title: "Installing Sprout"
 order: 0
 ---
 
-{{< include _preamble.qmd >}}
-
 ## Preparing to install Sprout
 
 Before installing Sprout, you need to have

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -5,6 +5,8 @@ order: 0
 
 {{< include _preamble.qmd >}}
 
+## Preparing to install Sprout
+
 Before installing Sprout, you need to have [Python](https://www.python.org/downloads/) and a Python package manager installed. For the latter, we recommend using uv which can be [installed via a shell script](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) or [via pipx](https://docs.astral.sh/uv/getting-started/installation/#pypi).
 
 To check that these programs are installed, run the following commands
@@ -19,20 +21,17 @@ If Python and uv are installed, these commands will show you the
 versions installed on your system. If you get an error, you need to
 install them before continuing.
 
-## Install Sprout in a virtual environment (recommended)
+### Setting up a Python project
 
 While you could install sprout globally (via pip, pipx, etc), we recommend
 installing it (and any other python packages you use) locally in a separate
 virtual environment for each project you are working on. This makes it easier
 to keep track of which package versions you are using for a specific project
-which increases reproducibility.
+which in turn increases reproducibility.
 
-To create a virtual environment for your project, you can use uv to
-initialize a "Python project". uv This will add the required files to keep track of your virtual environment and also add files
-
-You can create a Python project using [uv](https://docs.astral.sh/uv/).
-In short, you can create a new project using uv by running the following
-command in your Terminal (assuming we make a new data package called
+The first step in creating a virtual environment for your project, is to use uv
+to initialize a [Python project](https://docs.astral.sh/uv/guides/projects/#creating-a-new-project). You can create a new project by running the
+following command in your Terminal (assuming we want to call our project
 `diabetes-study`):
 
 ``` {.bash filename="Terminal"}
@@ -40,7 +39,7 @@ uv init diabetes-study
 ```
 
 This will create a new directory called `diabetes-study` with the basic
-structure of a Python project. It should look like:
+structure of a Python project:
 
 <!-- TODO: Auto-create this some how? -->
 
@@ -52,44 +51,40 @@ diabetes-study/
 ├── README.md
 ├── main.py
 └── pyproject.toml
-```
+``
 
-uv also creates the folder as a Git repository. For more information on
-working on projects with uv, see their
-[guide](https://docs.astral.sh/uv/guides/projects/). Of the files
-created, the most important ones for your data package are the
-`pyproject.toml` and `main.py` files. The `pyproject.toml` file is used
-to manage the dependencies of the project, while the `main.py` file is
-where you will coordinate the Python scripts in your project.
+Of the files created, the most important ones for your data package are the
+`pyproject.toml` and `main.py` files. The `pyproject.toml` file is used to
+manage the dependencies of the project, while the `main.py` file is where you
+will coordinate the Python scripts in your project. As you can see, uv also
+created the folder as a Git repository, so that you can keep the changes you make under version control.
 
 <!-- TODO: eventually flip callout content so the template is recommended and not uv -->
 
-::: callout-tip
-You can generate the basic structure of a data package by using the
-Seedcase Project
-[`template-data-package`](https://github.com/seedcase-project/template-data-package).
-There are instructions there on how to use it to make the initial
-structure of a data package.
-:::
+### Adding useful files via a project template
+
+In addition to project structure created by `uv init`, there are other
+configuration files that could help you work in a reproducible and effective
+manner with your data, e.g. by setting up code formatting and adding license
+information. We have created a project template that allows you to easily copy
+these files into your newly created Python project without having to create
+them all from scratch.
+
+We recommend that you use this template by [following the project template documentation](https://template-data-package.seedcase-project.org/docs/guide) under the headings "Installing" and "Creating a new data package".
+
+## Installing Sprout in the project's virtual environment
 
 After creating the project, open the project folder (in this case
-`diabetes-study`) in your Terminal. Run the `pwd` command to confirm
-that your working directory is the project folder.
-
-You can now install Sprout with this command:
+`diabetes-study`) in your Terminal. You can now install Sprout locally in the
+project's virtual environment with the following command:
 
 ``` {.bash filename="Terminal"}
 uv add seedcase-sprout
 ```
 
-Check that Sprout has been installed correctly by running this command:
+If the command runs successfully, the output should include a line saying
+something like "Installed 13 packages in 10ms", followed by a list of the
+installed packages which includes seedcase-sprout and all its required
+dependencies.
 
-``` {.bash filename="Terminal"}
-uv pip show seedcase_sprout
-```
-
-If Sprout has been installed successfully, the output will show details
-about Sprout.
-
-Get started with your first data package by following the guide on
-[Creating and managing data packages](/docs/guide/packages.qmd).
+Now that you have installed Sprout, the next step is to use it to create and manage your data and metadata as a "data package". This is what you will learn about in the next section of this guide.

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -28,8 +28,8 @@ install them before continuing.
 
 ### Setting up a Python project
 
-While you could install sprout globally (via pip, pipx, etc), we recommend
-installing it (and any other python packages you use) locally in a separate
+While you could install Sprout globally (e.g. with pip or pipx), we recommend
+installing it (and any other Python packages you use) locally in a separate
 virtual environment for each project you are working on. This makes it easier
 to keep track of which package versions you are using for a specific project
 which in turn increases reproducibility.
@@ -59,7 +59,7 @@ diabetes-study/
 └── pyproject.toml
 ```
 
-Of the files created, the most important ones for your data package are the
+Of the files created, the most important ones for your Data Package are the
 `pyproject.toml` and `main.py` files. The `pyproject.toml` file is used to
 manage the dependencies of the project, while the `main.py` file is where you
 will coordinate the Python scripts in your project. As you can see, uv also
@@ -77,9 +77,9 @@ information. We have created a project template that allows you to easily copy
 these files into your newly created Python project without having to create
 them all from scratch.
 
-We recommend that you use this template by [following the project template
-documentation](https://template-data-package.seedcase-project.org/docs/guide)
-under the headings "Installing" and "Creating a new data package".
+We recommend that you use this template by following the project template
+[documentation](https://template-data-package.seedcase-project.org/docs/guide)
+under the headings "Installing" and "Creating a new Data Package".
 
 ## Installing Sprout in the project's virtual environment
 
@@ -93,9 +93,9 @@ uv add seedcase-sprout
 
 If the command runs successfully, the output should include a line saying
 something like "Installed 13 packages in 10ms", followed by a list of the
-installed packages which includes seedcase-sprout and all its required
+installed packages which includes Sprout and all its required
 dependencies.
 
 Now that you have installed Sprout, the next step is to use it to create and
-manage your data and metadata as a "data package". This is what you will learn
+manage your data and metadata as a "Data Package". This is what you will learn
 about in the next section of this guide.

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -21,12 +21,14 @@ install them before continuing.
 
 ## Install Sprout in a virtual environment (recommended)
 
-It's generally recommended to install Python packages in a virtual
-environment to keep a project's dependencies separate from the
-system-wide Python setup and avoid conflicts. There are several tools to
-manage package dependencies and create virtual environments, such as
-venv, virtualenv, and uv. For this guide, we will use
-[uv](https://docs.astral.sh/uv/).
+While you could install sprout globally (via pip, pipx, etc), we recommend
+installing it (and any other python packages you use) locally in a separate
+virtual environment for each project you are working on. This makes it easier
+to keep track of which package versions you are using for a specific project
+which increases reproducibility.
+
+To create a virtual environment for your project, you can use uv to
+initialize a "Python project". uv This will add the required files to keep track of your virtual environment and also add files
 
 You can create a Python project using [uv](https://docs.astral.sh/uv/).
 In short, you can create a new project using uv by running the following
@@ -91,21 +93,3 @@ about Sprout.
 
 Get started with your first data package by following the guide on
 [Creating and managing data packages](/docs/guide/packages.qmd).
-
-## Install Sprout in system-wide
-
-We strongly recommend using Sprout in a virtual environment, but you can
-also install it system-wide. The easiest way to do that is to use pipx:
-
-``` {.bash filename="Terminal"}
-pipx install seedcase-sprout
-```
-
-To check that Sprout has been installed correctly, run the following and
-make sure `seedcase_sprout` is listed:
-
-``` {.bash filename="Terminal"}
-pipx list
-```
-
-Now you can use Sprout in any Python script throughout your computer.

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -63,7 +63,8 @@ Of the files created, the most important ones for your data package are the
 `pyproject.toml` and `main.py` files. The `pyproject.toml` file is used to
 manage the dependencies of the project, while the `main.py` file is where you
 will coordinate the Python scripts in your project. As you can see, uv also
-created the folder as a Git repository, so that you can keep the changes you make under version control.
+created the folder as a Git repository, so that you can keep the changes you
+make under version control.
 
 <!-- TODO: eventually flip callout content so the template is recommended and not uv -->
 

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -7,7 +7,12 @@ order: 0
 
 ## Preparing to install Sprout
 
-Before installing Sprout, you need to have [Python](https://www.python.org/downloads/) and a Python package manager installed. For the latter, we recommend using uv which can be [installed via a shell script](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) or [via pipx](https://docs.astral.sh/uv/getting-started/installation/#pypi).
+Before installing Sprout, you need to have
+[Python](https://www.python.org/downloads/) and a Python package manager
+installed. For the latter, we recommend using uv which can be [installed via
+a shell
+script](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer)
+or [via pipx](https://docs.astral.sh/uv/getting-started/installation/#pypi).
 
 To check that these programs are installed, run the following commands
 in your Terminal:
@@ -30,9 +35,10 @@ to keep track of which package versions you are using for a specific project
 which in turn increases reproducibility.
 
 The first step in creating a virtual environment for your project, is to use uv
-to initialize a [Python project](https://docs.astral.sh/uv/guides/projects/#creating-a-new-project). You can create a new project by running the
-following command in your Terminal (assuming we want to call our project
-`diabetes-study`):
+to initialize a [Python
+project](https://docs.astral.sh/uv/guides/projects/#creating-a-new-project).
+You can create a new project by running the following command in your Terminal
+(assuming we want to call our project `diabetes-study`):
 
 ``` {.bash filename="Terminal"}
 uv init diabetes-study
@@ -70,7 +76,9 @@ information. We have created a project template that allows you to easily copy
 these files into your newly created Python project without having to create
 them all from scratch.
 
-We recommend that you use this template by [following the project template documentation](https://template-data-package.seedcase-project.org/docs/guide) under the headings "Installing" and "Creating a new data package".
+We recommend that you use this template by [following the project template
+documentation](https://template-data-package.seedcase-project.org/docs/guide)
+under the headings "Installing" and "Creating a new data package".
 
 ## Installing Sprout in the project's virtual environment
 
@@ -87,4 +95,6 @@ something like "Installed 13 packages in 10ms", followed by a list of the
 installed packages which includes seedcase-sprout and all its required
 dependencies.
 
-Now that you have installed Sprout, the next step is to use it to create and manage your data and metadata as a "data package". This is what you will learn about in the next section of this guide.
+Now that you have installed Sprout, the next step is to use it to create and
+manage your data and metadata as a "data package". This is what you will learn
+about in the next section of this guide.

--- a/docs/guide/installation.qmd
+++ b/docs/guide/installation.qmd
@@ -57,7 +57,7 @@ diabetes-study/
 ├── README.md
 ├── main.py
 └── pyproject.toml
-``
+```
 
 Of the files created, the most important ones for your data package are the
 `pyproject.toml` and `main.py` files. The `pyproject.toml` file is used to


### PR DESCRIPTION
# Description

Mostly adding explanations and additional context to some of the installation steps.

This is a step towards #1575 but that will not be closed until a future PR (coming soon to GitHub near you)

Needs an in-depth review.

## Checklist

- [x] Formatted Markdown
- [ ] Ran `just run-all`
