### PR TITLE
docs: :memo: reorder interface toc to match index page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -52,8 +52,8 @@ website:
         - section: "Interface"
           href: docs/design/interface/index.qmd
           contents:
-            - docs/design/interface/outputs.qmd
             - docs/design/interface/inputs.qmd
+            - docs/design/interface/outputs.qmd
             - docs/design/interface/functions.qmd
             - docs/design/interface/flows.qmd
     - id: guide


### PR DESCRIPTION
# Description

The [interface index page lists inputs before outputs](https://sprout.seedcase-project.org/docs/design/interface/), which I think also makes more sense intuitively, so I suggests that the pages in the ToC are in the same order

Needs a quick review.

