### PR TITLE
docs: 🔥 remove highly coupled example code in docstrings

### DIFF
--- a/src/seedcase_sprout/internals/get.py
+++ b/src/seedcase_sprout/internals/get.py
@@ -33,18 +33,6 @@ def _get_nested_attr(
     Raises:
         ValueError: If the attribute chain contains an element that is not a valid
             identifier.
-
-    Examples:
-        ```{python}
-        class Inner:
-            pass
-        class Middle:
-            inner: Inner = Inner()
-        class Outer:
-            middle: Middle = Middle()
-
-        _get_nested_attr(Outer(), "middle.inner")
-        ```
     """
     attributes_list = attributes.split(".")
     if any(not attribute.isidentifier() for attribute in attributes_list):

--- a/src/seedcase_sprout/join_resource_batches.py
+++ b/src/seedcase_sprout/join_resource_batches.py
@@ -46,18 +46,6 @@ def join_resource_batches(
             shapes, such as mismatched column names or numbers.
         polars.exceptions.SchemaError: If the dataframes in data_list have
             different schemas, e.g., their column data types don't match.
-
-    Examples:
-        ```{python}
-        import seedcase_sprout as sp
-
-        with sp.ExamplePackage():
-            resource_properties = sp.example_resource_properties()
-            sp.write_resource_batch(sp.example_data(), resource_properties)
-            batches = sp.read_resource_batches(resource_properties=resource_properties)
-
-            sp.join_resource_batches(batches, resource_properties)
-        ```
     """
     check_resource_properties(resource_properties)
 

--- a/src/seedcase_sprout/read_resource_batches.py
+++ b/src/seedcase_sprout/read_resource_batches.py
@@ -47,17 +47,6 @@ def read_resource_batches(
         ValueError: If the batch file name is not in the expected pattern.
         ValueError: If the timestamp column name matches an existing column in the
             DataFrame.
-
-    Examples:
-        ``` {python}
-        import seedcase_sprout as sp
-
-        with sp.ExamplePackage():
-            resource_properties = sp.example_resource_properties()
-            sp.write_resource_batch(sp.example_data(), resource_properties)
-
-            sp.read_resource_batches(resource_properties)
-        ```
     """
     check_resource_properties(resource_properties)
     if paths is None:

--- a/src/seedcase_sprout/write_resource_data.py
+++ b/src/seedcase_sprout/write_resource_data.py
@@ -32,19 +32,6 @@ def write_resource_data(
 
     Returns:
         The path of the created Parquet file.
-
-    Examples:
-        ```{python}
-        import seedcase_sprout as sp
-
-        with sp.ExamplePackage():
-            resource_properties = sp.example_resource_properties()
-            # Add and join batch files
-            sp.write_resource_batch(sp.example_data(), resource_properties)
-            batches = sp.read_resource_batches(resource_properties)
-            data = sp.join_resource_batches(batches, resource_properties)
-            # Write resource data file
-            sp.write_resource_data(data, resource_properties)
     """
     check_data(data, resource_properties)
     data_path = PackagePath(package_path).resource_data(str(resource_properties.name))


### PR DESCRIPTION
# Description

Highly coupled example code isn't very maintainable. So I removed the examples that are too coupled.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
