### PR TITLE
docs: 🏗️ add design of extract metadata CLI

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -52,6 +52,8 @@ website:
             - docs/design/interface/inputs.qmd
             - docs/design/interface/outputs.qmd
             - docs/design/interface/functions.qmd
+            - docs/design/interface/cli.qmd
+            - docs/design/interface/python.qmd
             - docs/design/interface/flows.qmd
     - id: guide
       contents:

--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -34,9 +34,11 @@ commands. These commands are described below.
 
 ### {{< var wip >}} `extract-metadata`
 
-The `extract-metadata` command extracts metadata from a Parquet file
-and outputs a Python script with the `ResourceProperties()`
-dataclass filled in with the extracted metadata. It is meant to be used with Parquet files in the `staging/` directory that have the same schema (columns and data types) as the final resource. It has the signature:
+The `extract-metadata` command extracts metadata from a Parquet file and outputs
+a Python script with the `ResourceProperties()` dataclass filled in with the
+extracted metadata. It is meant to be used with Parquet files in the `staging/`
+directory that have the same schema (columns and data types) as the final
+resource. It has the signature:
 
 ```bash {filename="Terminal"}
 seedcase-sprout extract-metadata [PARQUET-PATH] --output/-o [OUTPUT-PATH]
@@ -47,9 +49,9 @@ seedcase-sprout extract-metadata [PARQUET-PATH] --output/-o [OUTPUT-PATH]
 %%| fig-cap: "The flow of input and output through the CLI `extract-metadata` command."
 %%| fig-alt: >-
 %%|   Diagram showing the flow of input and output through the CLI
-%%|   `extract-metadata` command. The user provides the path to the Parquet
-%%|   file and the output file, which are used
-%%|   to generate a Python script with extracted metadata.
+%%|   `extract-metadata` command. The user provides the path to the Parquet file
+%%|   and the output file, which are used to generate a Python script with
+%%|   extracted metadata.
 
 flowchart LR
     parquet[/"Parquet file<br>[PARQUET-FILE]"/]

--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -1,0 +1,63 @@
+---
+title: "Command line interface"
+---
+
+This document describes the command-line interface (CLI) as a development
+reference and to track implementation status.
+
+{{< include /docs/includes/_design-status.qmd >}}
+
+## {{< var wip >}} `seedcase-sprout`
+
+`seedcase-sprout` has the following signature:
+
+```bash {filename="Terminal"}
+seedcase-sprout <COMMAND> [PARAMETERS]
+```
+
+When used on its own, `seedcase-sprout` shows the help message as a shorthand
+for `--help`:
+
+```bash {filename="Terminal"}
+seedcase-sprout
+```
+
+::: callout-note
+As a convenience, we provide the command `sprout` as a shorthand for
+`seedcase-sprout`. It can be used in place of `seedcase-sprout` in all
+instances.
+:::
+
+`seedcase-sprout` has several commands: `extract-metadata`, `create-template`,
+`build-resources`, `build-metadata`, and `build` that runs the other `build-*`
+commands. These commands are described below.
+
+### {{< var wip >}} `extract-metadata`
+
+The `extract-metadata` command extracts metadata from a Parquet file in the
+`staging/` directory and outputs a Python script with `ResourceProperties()`
+dataclass filled in with the extracted metadata. It has the signature:
+
+```bash {filename="Terminal"}
+seedcase-sprout extract-metadata [PARQUET-FILE] --output/-o [OUTPUT-FILE]
+```
+
+```{mermaid}
+%%| label: fig-cli-extract-metadata-flow
+%%| fig-cap: "The flow of input and output through the CLI `extract-metadata` command."
+%%| fig-alt: >-
+%%|   Diagram showing the flow of input and output through the CLI
+%%|   `extract-metadata` command. The user provides the source of the Parquet
+%%|   file and the output file, which are used by the `extract-metadata` command
+%%|   to generate the Python script with extracted metadata.
+
+flowchart LR
+    parquet[/"Parquet file<br>[PARQUET-FILE]"/]
+    output_opt["Output file<br>[--output]"]
+    extract["extract-metadata"]
+    output[/"Python script<br>[File]"/]
+
+    parquet --> extract
+    output_opt --> extract
+    extract --> output
+```

--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -34,12 +34,12 @@ commands. These commands are described below.
 
 ### {{< var wip >}} `extract-metadata`
 
-The `extract-metadata` command extracts metadata from a Parquet file in the
-`staging/` directory and outputs a Python script with `ResourceProperties()`
-dataclass filled in with the extracted metadata. It has the signature:
+The `extract-metadata` command extracts metadata from a Parquet file
+and outputs a Python script with the `ResourceProperties()`
+dataclass filled in with the extracted metadata. It is meant to be used with Parquet files in the `staging/` directory that have the same schema (columns and data types) as the final resource. It has the signature:
 
 ```bash {filename="Terminal"}
-seedcase-sprout extract-metadata [PARQUET-FILE] --output/-o [OUTPUT-FILE]
+seedcase-sprout extract-metadata [PARQUET-PATH] --output/-o [OUTPUT-PATH]
 ```
 
 ```{mermaid}
@@ -47,9 +47,9 @@ seedcase-sprout extract-metadata [PARQUET-FILE] --output/-o [OUTPUT-FILE]
 %%| fig-cap: "The flow of input and output through the CLI `extract-metadata` command."
 %%| fig-alt: >-
 %%|   Diagram showing the flow of input and output through the CLI
-%%|   `extract-metadata` command. The user provides the source of the Parquet
-%%|   file and the output file, which are used by the `extract-metadata` command
-%%|   to generate the Python script with extracted metadata.
+%%|   `extract-metadata` command. The user provides the path to the Parquet
+%%|   file and the output file, which are used
+%%|   to generate a Python script with extracted metadata.
 
 flowchart LR
     parquet[/"Parquet file<br>[PARQUET-FILE]"/]

--- a/docs/design/interface/cli.qmd
+++ b/docs/design/interface/cli.qmd
@@ -54,8 +54,8 @@ seedcase-sprout extract-metadata [PARQUET-PATH] --output/-o [OUTPUT-PATH]
 %%|   extracted metadata.
 
 flowchart LR
-    parquet[/"Parquet file<br>[PARQUET-FILE]"/]
-    output_opt["Output file<br>[--output]"]
+    parquet[/"Parquet path<br>[PARQUET-PATH]"/]
+    output_opt["Output path<br>[--output]"]
     extract["extract-metadata"]
     output[/"Python script<br>[File]"/]
 

--- a/docs/design/interface/flows.qmd
+++ b/docs/design/interface/flows.qmd
@@ -59,39 +59,6 @@ flowchart
     path_properties --> write_properties
 ```
 
-## Extracting properties from data
-
-The flow for extracting a resource's field properties from data. This is useful
-when the data is in a format that contains metadata about the data, such as a
-CSV file with a header row that contains the column names. While the
-`extract_field_properties()` function extracts all *required* `FieldProperties`
-from the data, there are many optional properties that are still very useful and
-should be filled in manually. The output of the `extract_field_properties()`
-function can be used to generate a Python script to give you a starting point
-for writing the resource properties. Afterwards, if you want to update the
-resource properties, you'll edit this Python script and then re-run your build
-process to generate the `datapackage.json` file with the updated properties.
-
-```{mermaid}
-%%| label: fig-flow-extract-field-properties
-%%| fig-cap: >-
-%%|   Diagram showing the flow of objects and functions to extract a resource's
-%%|   field properties from data.
-%%| fig-alt: "A flow diagram showing the steps to extract field properties from data."
-
-flowchart
-    data[("DataFrame<br>(Tidy)")]
-    properties_extracted[("FieldProperties<br>(extracted)")]
-    extract_field_properties("extract_field_properties()")
-    python_script("Python script<br>(generated with<br>extracted properties)")
-    create_script("create_resource_properties_script()")
-
-    data --> extract_field_properties
-    extract_field_properties --> properties_extracted
-    properties_extracted --> create_script
-    create_script --> python_script
-```
-
 ## Saving new or modified data to batch
 
 A data resource needs data, not just properties. You can add data to any data

--- a/docs/design/interface/python.qmd
+++ b/docs/design/interface/python.qmd
@@ -22,7 +22,9 @@ metadata.
 %%| fig-cap: >-
 %%|   Diagram showing the flow of objects and functions to extract a resource's
 %%|   metadata from data.
-%%| fig-alt: "A flow diagram showing the steps to extract resource metadata from a Parquet file."
+%%| fig-alt: >-
+%%|   A flow diagram showing the steps to extract resource metadata from a
+%%|   Parquet file.
 
 flowchart
     parquet[/"Parquet data<br>[PARQUET-FILE]"/]

--- a/docs/design/interface/python.qmd
+++ b/docs/design/interface/python.qmd
@@ -11,9 +11,9 @@ the library layer, as well as tracking implementation status.
 
 ### {{< var planned >}} `extract_metadata()`
 
-`extract_metadata()` has two arguments: `parquet_file` and `output_file`. The
-`parquet_file` argument is the path to a Parquet file in, e.g. the `staging/`
-directory, and the `output_file` argument is the path to the Python script that
+`extract_metadata()` has two arguments: `parquet_path` and `output_path`. The
+`parquet_path` argument is the path to a Parquet file in, e.g. the `staging/`
+directory, and the `output_path` argument is the path to the Python script that
 will have the `ResourceProperties()` dataclass filled in with the extracted
 metadata.
 
@@ -27,13 +27,13 @@ metadata.
 %%|   Parquet file.
 
 flowchart
-    parquet[/"Parquet data<br>[PARQUET-FILE]"/]
+    parquet[/"Parquet data<br>[PARQUET-PATH]"/]
     read_parquet["read_parquet()"]
-    output_opt["Output file<br>[--output]"]
+    output_opt["Output path<br>[--output]"]
     output[/"Python script<br>[File]"/]
     data[("DataFrame<br>(Tidy)")]
     extract_resource_metadata("extract_resource_metadata()")
-    metadata[("FieldProperties<br>(extracted)")]
+    metadata[("ResourceProperties<br>(extracted)")]
 
     parquet --> read_parquet
     read_parquet --> data

--- a/docs/design/interface/python.qmd
+++ b/docs/design/interface/python.qmd
@@ -1,0 +1,43 @@
+---
+title: "Python interface"
+---
+
+This document describes the design of the Python functions forming the CLI and
+the library layer, as well as tracking implementation status.
+
+{{< include /docs/includes/_design-status.qmd >}}
+
+## CLI functions
+
+### {{< var planned >}} `extract_metadata()`
+
+`extract_metadata()` has two arguments: `parquet_file` and `output_file`. The
+`parquet_file` argument is the path to a Parquet file in, e.g. the `staging/`
+directory, and the `output_file` argument is the path to the Python script that
+will have the `ResourceProperties()` dataclass filled in with the extracted
+metadata.
+
+```{mermaid}
+%%| label: fig-flow-extract-resource-metadata
+%%| fig-cap: >-
+%%|   Diagram showing the flow of objects and functions to extract a resource's
+%%|   metadata from data.
+%%| fig-alt: "A flow diagram showing the steps to extract resource metadata from data."
+
+flowchart
+    parquet[/"Parquet data<br>[PARQUET-FILE]"/]
+    read_parquet["read_parquet()"]
+    output_opt["Output file<br>[--output]"]
+    output[/"Python script<br>[File]"/]
+    data[("DataFrame<br>(Tidy)")]
+    extract_resource_metadata("extract_resource_metadata()")
+    metadata[("FieldProperties<br>(extracted)")]
+
+    parquet --> read_parquet
+    read_parquet --> data
+    data --> extract_resource_metadata
+    extract_resource_metadata --> metadata
+    output_opt --> write_metadata["write_resource_metadata()"]
+    metadata --> write_metadata
+    write_metadata --> output
+```

--- a/docs/design/interface/python.qmd
+++ b/docs/design/interface/python.qmd
@@ -22,7 +22,7 @@ metadata.
 %%| fig-cap: >-
 %%|   Diagram showing the flow of objects and functions to extract a resource's
 %%|   metadata from data.
-%%| fig-alt: "A flow diagram showing the steps to extract resource metadata from data."
+%%| fig-alt: "A flow diagram showing the steps to extract resource metadata from a Parquet file."
 
 flowchart
     parquet[/"Parquet data<br>[PARQUET-FILE]"/]

--- a/docs/includes/_design-status.qmd
+++ b/docs/includes/_design-status.qmd
@@ -1,0 +1,13 @@
+We use symbols to indicate the status of implementation (see table
+below). For planned or in-progress work, we might include signatures,
+docstrings, and pseudocode to clarify the design. Once the interface is
+implemented, these are replaced by links to the reference documentation.
+
+|       Status        | Description                                                     |
+|:-------------------:|:----------------------------------------------------------------|
+|  {{< var done >}}   | Interface that has been implemented.                            |
+|   {{< var wip >}}   | Interface that is currently being worked on.                    |
+| {{< var planned >}} | Interface that is planned, but isn't being worked on currently. |
+
+: A table showing the symbols used to indicate the status of interface
+components, along with their descriptions.

--- a/docs/includes/_design-status.qmd
+++ b/docs/includes/_design-status.qmd
@@ -1,13 +1,13 @@
-We use symbols to indicate the status of implementation (see table
-below). For planned or in-progress work, we might include signatures,
-docstrings, and pseudocode to clarify the design. Once the interface is
-implemented, these are replaced by links to the reference documentation.
+We use symbols to indicate the status of implementation (see table below). For
+planned or in-progress work, we might include signatures, docstrings, and
+pseudocode to clarify the design. Once the interface is implemented, these are
+replaced by links to the reference documentation.
 
-|       Status        | Description                                                     |
-|:-------------------:|:----------------------------------------------------------------|
-|  {{< var done >}}   | Interface that has been implemented.                            |
-|   {{< var wip >}}   | Interface that is currently being worked on.                    |
-| {{< var planned >}} | Interface that is planned, but isn't being worked on currently. |
+  | Status              | Description                                                     |
+  | :-----------------: | :-------------------------------------------------------------- |
+  |  {{< var done >}}   | Interface that has been implemented.                            |
+  |   {{< var wip >}}   | Interface that is currently being worked on.                    |
+  | {{< var planned >}} | Interface that is planned, but isn't being worked on currently. |
 
-: A table showing the symbols used to indicate the status of interface
-components, along with their descriptions.
+  : A table showing the symbols used to indicate the status of interface
+    components, along with their descriptions.


### PR DESCRIPTION
# Description

Potential design for the CLI for extracting metadata from a Parquet file.

Related to #1682

Needs a thorough review.

## Checklist

- [ ] Ran `just run-all`
