### PR TITLE
fix: 🐛 remove extra quartodoc build step

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -124,9 +124,6 @@ jobs:
       - name: Build function reference docs
         run: uv run quartodoc build
 
-      - name: Build function reference docs
-        run: uvx quartodoc build
-
       # Check that the website builds, but don't publish it
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0


### PR DESCRIPTION
# Description

There was this ?leftover? quartodoc build step that was not running in the project env and caused the website build to fail. Also needs to be fixed in Template Python Package, but I don't seem to have write access ([issue](https://github.com/seedcase-project/template-python-package/issues/321)).

Closes #

Needs a quick review.

## Checklist

- [x] Ran `just run-all` -- pre-commit is also failing remotely, but that's a separate pyrefly issue
