### PR TITLE
chore: 🔧 don't fix use of `Optional[]` by Ruff

### DIFF
--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -13,8 +13,12 @@ extend-select = [
   # Check for unused arguments.
   "ARG",
 ]
-# Ignore missing docstring at the top of files.
-ignore = ["D100"]
+ignore = [
+  # Ignore missing docstring at the top of files.
+  "D100",
+  # Use `Optional[]` typing.
+  "UP045",
+]
 
 [lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
# Description

Small fix to prevent formatting fixes to use of `Optional[]`.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
