### PR TITLE
docs: 🎨 fix Markdown formatting, issue with formatter and def lists

### DIFF
--- a/docs/design/interface/inputs.qmd
+++ b/docs/design/interface/inputs.qmd
@@ -11,52 +11,50 @@ The objects we primarily incorporate in the interface are paths, properties, and
 data, as described in the [naming](/docs/design/architecture/naming.qmd#naming)
 document.
 
-Paths
+## Paths
 
-:   These objects are always `Path` objects from Python's
-    [`pathlib`](https://docs.python.org/3/library/pathlib.html).
+These objects are always `Path` objects from Python's
+[`pathlib`](https://docs.python.org/3/library/pathlib.html).
 
-Properties
+## Properties
 
-:   These are Python
-    [dataclasses](https://docs.python.org/3/library/dataclasses.html) we've
-    created to represent the properties (metadata) of a data package or
-    resource. They always use the `*Properties` suffix, such as
-    `SproutProperties` and `ResourceProperties`. While `SproutProperties` holds
-    general Data Package properties, we intentionally avoided a name such as
-    `DataPackageProperties` to communicate that Sprout uses stricter criteria
-    for some properties than the full flexibility that is available in the Data
-    Package specification.
+These are Python
+[dataclasses](https://docs.python.org/3/library/dataclasses.html) we've created
+to represent the properties (metadata) of a data package or resource. They
+always use the `*Properties` suffix, such as `SproutProperties` and
+`ResourceProperties`. While `SproutProperties` holds general Data Package
+properties, we intentionally avoided a name such as `DataPackageProperties` to
+communicate that Sprout uses stricter criteria for some properties than the full
+flexibility that is available in the Data Package specification.
 
-Data
+## Data
 
-:   These data input objects are always
-    [Polars](https://decisions.seedcase-project.org/why-polars-for-data-cleaning/)
-    `DataFrame` objects.
+These data input objects are always
+[Polars](https://decisions.seedcase-project.org/why-polars-for-data-cleaning/)
+`DataFrame` objects.
 
-:   Sprout expects the data objects to be in a
-    [tidy](https://vita.had.co.nz/papers/tidy-data.html) format. Tidy data is a
-    conceptual framework around how data should be structured to be optimally
-    usable for analysis. This is similar to what is called [third normal
-    form](https://en.wikipedia.org/wiki/Third_normal_form) in relational
-    database development, excluding the emphasis on creating additional tables
-    to reduce redundancy.
+Sprout expects the data objects to be in a
+[tidy](https://vita.had.co.nz/papers/tidy-data.html) format. Tidy data is a
+conceptual framework around how data should be structured to be optimally usable
+for analysis. This is similar to what is called [third normal
+form](https://en.wikipedia.org/wiki/Third_normal_form) in relational database
+development, excluding the emphasis on creating additional tables to reduce
+redundancy.
 
-:   Tidy data has the following properties:
+Tidy data has the following properties:
 
-    1. Each variable forms a column.
-    2. Each observation forms a row.
-    3. Each cell has a single value that represents both the column and row
-       entity.
+1. Each variable forms a column.
+2. Each observation forms a row.
+3. Each cell has a single value that represents both the column and row entity.
 
-    This tidy structure makes it easier to process and use the data for later
-    analysis. If it is already in this form, there is less need to transform it
-    later.
+This tidy structure makes it easier to process and use the data for later
+analysis. If it is already in this form, there is less need to transform it
+later.
 
-:   We have set a requirement on using tidy data frames because it simplifies
-    the workflow and allows users to use their own, potentially highly
-    customised, workflows for processing their data. This also allows for a more
-    flexible and user-friendly interface to Sprout, since it removes the need to
-    support or consider all the wide variety of formats data can be stored or
-    structured in. Because data processing and organizing can be so strongly
-    dependent on the domain, we leave this to the user to handle.
+We have set a requirement on using tidy data frames because it simplifies the
+workflow and allows users to use their own, potentially highly customised,
+workflows for processing their data. This also allows for a more flexible and
+user-friendly interface to Sprout, since it removes the need to support or
+consider all the wide variety of formats data can be stored or structured in.
+Because data processing and organizing can be so strongly dependent on the
+domain, we leave this to the user to handle.


### PR DESCRIPTION
# Description

The formatter kept breaking the def list. So this just removes the def list.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
