### PR TITLE
build: 🔨 split into `format-md` and `check-md`

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,9 +59,11 @@ format-docstrings:
 
 # Format Markdown files
 format-md:
-  # Use both rumdl and panache, for different purposes
-  uvx rumdl fmt --silent
   uvx --from panache-cli panache format . --quiet
+
+# Check Markdown files
+check-md:
+  uvx rumdl check
 
 # Check Python code for any errors that need manual attention
 check-python:


### PR DESCRIPTION
# Description

rumdl was breaking lists in callout blocks, so just splitting it into a `check-md` recipe.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
