### PR TITLE
ci: 👷 check commits from latest tag, earlier ones will fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
         uses: cocogitto/cocogitto-action@52d0023b4396897f1815648e553db2ab8d782f3a # v4.2.0
         with:
           command: check
+          # The repo hasn't always used conventional commits, so we only check from the latest.
+          args: --from-latest-tag
 
       # Install uv to use git-cliff and panache
       - name: Set up uv


### PR DESCRIPTION
# Description

Cocogitto fails because there are non-conforming commits. This only checks from the last tag.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
