### PR TITLE
style: 🔧 match guide page style with other packages

### DIFF
--- a/docs/guide/index.qmd
+++ b/docs/guide/index.qmd
@@ -6,9 +6,11 @@ description: >-
 listing:
   contents: .
   type: grid
+  grid-columns: 1
   sort: "order"
   fields:
     - title
+    - description
 ---
 
 {{< include _preamble.qmd >}}


### PR DESCRIPTION
# Description

Puts the guide items into a single column with a description, like in e.g. Flower.

Closes #1619 

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
